### PR TITLE
Remove unused command line flags

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -20,7 +20,3 @@ node_exporter_enabled_collectors:
   - vmstat
   - systemd
   - ntp
-
-node_exporter_config_flags:
-  'web.listen-address': '0.0.0.0:9100'
-  'log.level': 'info'


### PR DESCRIPTION
Command line flags used to be configurable; they aren't anymore. It might be a good idea to add them back eventually, but the only option I'm aware of that isn't supported by this role is "log.level".