### PR TITLE
custom docker images; support more OSes

### DIFF
--- a/.travis/images.sh
+++ b/.travis/images.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+for i in ubuntu-molecule:16.04 debian-molecule:9 debian-molecule:8 centos-molecule:7 fedora-molecule:27
+do 
+    docker pull paulfantom/$i &
+done
+
+wait

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -1,6 +1,6 @@
 ---
 galaxy_info:
-  author: Roman Demachkovych
+  author: Roman Demachkovych, Pawel Krupa
   description: Prometheus Node Exporter
   license: MIT
   min_ansible_version: 2.2
@@ -8,12 +8,21 @@ galaxy_info:
   - name: Ubuntu
     versions:
     - xenial
+  - name: Debian
+    versions:
+    - jessie
+    - stretch
   - name: EL
     versions:
     - 7
+  - name: Fedora
+    versions:
+    - 27
   galaxy_tags:
   - monitoring
   - prometheus
   - node-exporter
+  - metrics
+
 
 dependencies: []

--- a/molecule.yml
+++ b/molecule.yml
@@ -5,13 +5,39 @@ driver:
   name: docker
 verifier:
   name: testinfra
+dependency:
+  name: shell
+  command: ./.travis/images.sh
 docker:
+  build_image: False
   containers:
     - name: xenial
-      image: solita/ubuntu-systemd
+      image: paulfantom/ubuntu-molecule
       image_version: 16.04
       privileged: true
-    - name: centos
-      image: centos/systemd
-      image_version: latest
+      volume_mounts:
+        - /sys/fs/cgroup:/sys/fs/cgroup:ro
+    - name: stretch
+      image: paulfantom/debian-molecule
+      image_version: 9
       privileged: true
+      volume_mounts:
+        - /sys/fs/cgroup:/sys/fs/cgroup:ro
+    - name: jessie
+      image: paulfantom/debian-molecule
+      image_version: 8
+      privileged: true
+      volume_mounts:
+        - /sys/fs/cgroup:/sys/fs/cgroup:ro
+    - name: centos7
+      image: paulfantom/centos-molecule
+      image_version: 7
+      privileged: true
+      volume_mounts:
+        - /sys/fs/cgroup:/sys/fs/cgroup:ro
+    - name: fedora
+      image: paulfantom/fedora-molecule
+      image_version: 27
+      privileged: true
+      volume_mounts:
+        - /sys/fs/cgroup:/sys/fs/cgroup:ro

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -34,6 +34,12 @@
   notify:
     - restart node exporter
 
+- name: Install libcap on Debian systems
+  package:
+    name: "libcap2-bin"
+    state: present
+  when: ansible_os_family | lower == "debian"
+
 - name: Node exporter can read anything (omit file permissions)
   capabilities:
     path: '/opt/node_exporter'

--- a/tests/playbook.yml
+++ b/tests/playbook.yml
@@ -1,15 +1,5 @@
 ---
 - hosts: all
-  tasks:
-    - name: install testing suite
-      package:
-        name: "{{ item }}"
-        state: present
-      with_items:
-        - iproute
-        - net-tools
-
-- hosts: all
   any_errors_fatal: yes
   roles:
     - ansible-node-exporter

--- a/tests/test_default.py
+++ b/tests/test_default.py
@@ -4,32 +4,26 @@ testinfra_hosts = AnsibleRunner('.molecule/ansible_inventory').get_hosts('all')
 
 
 def test_files(host):
-    present = [
+    files = [
         "/etc/systemd/system/node_exporter.service",
         "/opt/node_exporter"
     ]
-    if present:
-        for file in present:
-            f = host.file(file)
-            assert f.exists
-            assert f.is_file
+    for file in files:
+        f = host.file(file)
+        assert f.exists
+        assert f.is_file
 
 
 def test_service(host):
-    present = [
-        "node_exporter"
-    ]
-    if present:
-        for service in present:
-            s = host.service(service)
-            assert s.is_enabled
-            assert s.is_running
+    s = host.service("node_exporter")
+    assert s.is_enabled
+    assert s.is_running
 
 
 def test_socket(host):
-    present = [
+    sockets = [
         "tcp://127.0.0.1:9100"
     ]
-    for socket in present:
+    for socket in sockets:
         s = host.socket(socket)
         assert s.is_listening


### PR DESCRIPTION
This changes a little how CI pipeline works.
Similiar to https://github.com/cloudalchemy/ansible-prometheus/pull/43 however with 2 minor changes:
- containers run in privileged mode, not with SYS_ADMIN capability. This is needed to give systemd access to change niceness (addind SYS_NICE doesn't work)
- location of `images.sh` is changed to ensure cleaner repository structure

Also tests are simplified, similiar to https://github.com/cloudalchemy/ansible-prometheus/pull/55