### PR TITLE
Make Prometheus node exporter restart/reload with sudo privileges.

### DIFF
--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,5 +1,6 @@
 ---
 - name: restart node exporter
+  become: true
   systemd:
     daemon_reload: yes
     name: node_exporter


### PR DESCRIPTION
I'm trying to include the `cloudalchemy.node-exporter` role from our own monitoring role like this:
```
- name: Deploy Prometheus Node Exporter
  become: yes
  include_role:
    name: cloudalchemy.node-exporter
  vars:
  [...]
```
This results in a fatal error, at the point when running the handler that should restart the node-exporter:
```
RUNNING HANDLER [cloudalchemy.node-exporter : restart node exporter] ****************************************************************************************************************
fatal: [monitor]: FAILED! => {"changed": false, "msg": "failure 1 during daemon-reload: Failed to execute operation: Interactive authentication required.\n"}
```
The service could only be restarted with sudo-privileges, which in the case of an `include_role` or `import_role` won't get picked up correctly by the handler responsible for the service-restart/-reload.
This PR will make sure that the `node_exporter.service` will be restarted with the correct privileges.