### PR TITLE
Modify when-statement to not include jinja2 templating delimiters such

### DIFF
--- a/tasks/preflight.yml
+++ b/tasks/preflight.yml
@@ -2,5 +2,5 @@
 - name: check collectors
   fail:
     msg: "Collector cannot be both disabled and enabled"
-  when: '"{{ item }}" in "{{ node_exporter_enabled_collectors }}"'
+  when: item in node_exporter_enabled_collectors
   with_items: "{{ node_exporter_disabled_collectors }}"


### PR DESCRIPTION
as {{ }} or {% %}, as this will raise a warning as from Ansible 2.3.