### PR TITLE
Fix check mode

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -45,7 +45,7 @@ We try to provide production ready ansible roles which should be as much zero-co
 
 ### Add tests
 
-We try to have as much tests written in testinfra framework as possible, so when you copy file, some template or starting some server just add couple of lines in [/tests/test)default.py](test_default.py) file. If you want to know how to write tests in testinfra, go to their [docs](http://testinfra.readthedocs.io/en/latest/index.html).
+We try to have as much tests written in testinfra framework as possible, so when you copy file, some template or starting some server just add couple of lines in [/tests/test/default.py](test_default.py) file. If you want to know how to write tests in testinfra, go to their [docs](http://testinfra.readthedocs.io/en/latest/index.html).
 
 ### Follow best practices
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -45,7 +45,7 @@ We try to provide production ready ansible roles which should be as much zero-co
 
 ### Add tests
 
-We try to have as much tests written in testinfra framework as possible, so when you copy file, some template or starting some server just add couple of lines in [/tests/test/default.py](test_default.py) file. If you want to know how to write tests in testinfra, go to their [docs](http://testinfra.readthedocs.io/en/latest/index.html).
+We try to have as much tests written in testinfra framework as possible, so when you copy file, some template or starting some server just add couple of lines in [/tests/test_default.py](test_default.py) file. If you want to know how to write tests in testinfra, go to their [docs](http://testinfra.readthedocs.io/en/latest/index.html).
 
 ### Follow best practices
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,6 @@ Deploy prometheus [node exporter](https://github.com/prometheus/node_exporter) u
 ## Requirements
 
 - Ansible >= 2.3
-- go-lang installed on deployer machine (same one where ansible is installed)
 
 ## Role Variables
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -35,6 +35,7 @@
     group: "node-exp"
   notify:
     - restart node exporter
+  when: not ansible_check_mode
 
 - name: Install libcap on Debian systems
   package:


### PR DESCRIPTION
One of the task was failing in check mode, as it didn't have the binary.
This could also have been done with some kind of dependency on the previous task.