### PR TITLE
Fix __pycache__ in .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,5 +9,5 @@
 *.idea
 .molecule
 .cache
-**__pycache__**
+__pycache__/
 .pytest_cache


### PR DESCRIPTION
Used syntax was invalid
__pycache__ would also have work but would have match both directories and files.
The trailing slash target only directories. 

As visible at https://git-scm.com/docs/gitignore double asterisks without slashes to target directories are invalid.

Every project of the organization seems to need the fix.