### PR TITLE
Fix test done using a filter

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -25,7 +25,7 @@
     remote_src: yes
     creates: "/tmp/node_exporter-{{ node_exporter_version }}.linux-{{ go_arch_map[ansible_architecture] | default(ansible_architecture) }}/node_exporter"
   register: _download_binary
-  until: _download_binary | success
+  until: _download_binary is succeeded
   retries: 5
   delay: 2
   delegate_to: localhost


### PR DESCRIPTION
This remove a dprecation warning and now use the correct tense.

This remove this warning on role execution:
```
[DEPRECATION WARNING]: Using tests as filters is deprecated. Instead of using `result|success` instead use `result is success`. This feature will be removed in version 2.9. Deprecation warnings can be disabled by
 setting deprecation_warnings=False in ansible.cfg.
```