### PR TITLE
Make node_exporter.service template compatible with both Python 2 and 3

### DIFF
--- a/templates/node_exporter.service.j2
+++ b/templates/node_exporter.service.j2
@@ -13,7 +13,7 @@ ExecStart=/usr/local/bin/node_exporter \
     {%   if not c is mapping -%}
     --collector.{{ c }} \
     {%   else -%}
-    {%     set name,opt = c.items()[0] -%}
+    {%     set name,opt = (c.items() | list)[0] -%}
     {%     for k,v in opt.items() -%}
     --collector.{{ name }}.{{ k }}={{ v }} \
     {%     endfor -%}


### PR DESCRIPTION
When using this role in an environment where the default python
interpreter is python3, the ansible run fails when jinja2 tries to
process `templates/node_exporter.service.j2`.

This is because in Python 3, `dict.items()` returns a *view object*
which can't be indexed directly (in Python 2, this returns a list).

Casting the result of `c.items()` explicitly to a list allows indexing
under Python 3 while not changing the outcome in Python 2.

When executed in a Python 3 environment, the order
in which the items are looped over might be different since "Keys and
values are listed in an arbitrary order which is non-random, varies
across Python implementations, and depends on the dictionary’s history
of insertions and deletions."
(https://docs.python.org/3.6/library/stdtypes.html#dict-views)

Otherwise, this change is functionally identical.