### PR TITLE
Fix architecture var parsing

### DIFF
--- a/vars/main.yml
+++ b/vars/main.yml
@@ -1,7 +1,7 @@
 ---
 go_arch_map:
-  i386: 386
-  x86_64: amd64
-  aarch64: arm64
-  armv7l: armv7
-  armv6l: armv6
+  i386: '386'
+  x86_64: 'amd64'
+  aarch64: 'arm64'
+  armv7l: 'armv7'
+  armv6l: 'armv6'


### PR DESCRIPTION
[fix] Explicity make architecture mapping strings to avoid string/int
confusion.