### PR TITLE
specify file name for dest in get_url call

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -21,7 +21,7 @@
   become: false
   get_url:
     url: "https://github.com/prometheus/node_exporter/releases/download/v{{ node_exporter_version }}/node_exporter-{{ node_exporter_version }}.linux-{{ go_arch_map[ansible_architecture] | default(ansible_architecture) }}.tar.gz"
-    dest: "/tmp"
+    dest: "/tmp/node_exporter-{{ node_exporter_version }}.linux-{{ go_arch_map[ansible_architecture] | default(ansible_architecture) }}.tar.gz"
     checksum: "sha256:{{ node_exporter_checksum }}"
   register: _download_binary
   until: _download_binary is succeeded


### PR DESCRIPTION
tested on ansible v2.5.3 and v2.4.4

The unarchive step failed as the get_url dest path ended up being /tmp/$UUID so unarchive could not find the source file. Not sure if there's something specific in my setup that caused this to fail.