### PR TITLE
reload-daemon on systemd enable

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -24,6 +24,7 @@
 - name: Ensure Node Exporter is enabled on boot
   become: true
   systemd:
+    daemon_reload: true
     name: node_exporter
     enabled: true
   tags:


### PR DESCRIPTION
On a clean install, need to reload-daemon for the service to be visible for enable.