### PR TITLE
Add support for Clear linux

### DIFF
--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -42,6 +42,12 @@ platforms:
     privileged: true
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:ro
+  - name: clearlinux
+    image: paulfantom/clearlinux-molecule:latest
+    docker_host: "${DOCKER_HOST:-unix://var/run/docker.sock}"
+    privileged: true
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:ro
 provisioner:
   name: ansible
   lint:

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -43,6 +43,12 @@
   delegate_to: localhost
   check_mode: false
 
+- name: Create /usr/local/bin
+  file:
+    path: /usr/local/bin
+    state: directory
+    mode: 0755
+
 - name: Propagate node_exporter binaries
   copy:
     src: "/tmp/node_exporter-{{ node_exporter_version }}.linux-{{ go_arch_map[ansible_architecture] | default(ansible_architecture) }}/node_exporter"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -2,6 +2,7 @@
 - name: Gather variables for each operating system
   include_vars: "{{ item }}"
   with_first_found:
+    - "{{ ansible_distribution_file_variety | lower }}.yml"
     - "{{ ansible_distribution | lower }}.yml"
     - "{{ ansible_os_family | lower }}.yml"
   tags:

--- a/vars/clearlinux.yml
+++ b/vars/clearlinux.yml
@@ -1,2 +1,3 @@
 ---
 node_exporter_dependencies:
+  - sysadmin-basic

--- a/vars/clearlinux.yml
+++ b/vars/clearlinux.yml
@@ -1,0 +1,2 @@
+---
+node_exporter_dependencies:


### PR DESCRIPTION
Building on https://github.com/paulfantom/dockerfiles/pull/2, this pull request adds support for [Clear Linux](https://clearlinux.org/), a lightweight auto-updating distribution of Linux.

Clear Linux has one dependency: the `sysadmin-basic` "bundle". Bundles are how packages are installed in Clear Linux, and `sysadmin-basic` [includes `getcap`](https://github.com/clearlinux/clr-bundles/blob/7fe5ab8460645097a38e127c9b8fc96c4429f08c/bundles/sysadmin-basic#L50). This dependency was added to the `vars/clearlinux.yml` file.

I also had to add a task to ensure that `/usr/local/bin` is present, as it's not always in Clear Linux.

And lastly, as outlined in 94c3edd, I had to update the `with_first_round` to use `ansible_distribution_file_variety`, due to the way that Clear Linux returns `ansible_distribution` / `ansible_os_family` values for Ansible 2.4. Once support for Ansible 2.4 is dropped, we can remove that line.

