### PR TITLE
make textfile dir writable by node-exp group

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ All variables which can be overridden are stored in [defaults/main.yml](defaults
 | `node_exporter_web_listen_address` | "0.0.0.0:9100" | Address on which node exporter will listen |
 | `node_exporter_enabled_collectors` | [ systemd ] | List of additionally enabled collectors. It adds collectors to [those enabled by default](https://github.com/prometheus/node_exporter#enabled-by-default) |
 | `node_exporter_disabled_collectors` | [] | List of disabled collectors. By default node_exporter disables collectors listed [here](https://github.com/prometheus/node_exporter#disabled-by-default). |
+| `node_exporter_textfile_dir` | "/var/lib/node_exporter" | Directory used by the [Textfile Collector](https://github.com/prometheus/node_exporter#textfile-collector). To get permissions to write metrics in this directory, users must be in `node-exp` system group.
 
 ## Example
 

--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -6,7 +6,7 @@
     owner: "{{ node_exporter_system_user }}"
     group: "{{ node_exporter_system_group }}"
     recurse: true
-    mode: 0755
+    mode: 0775
   when: node_exporter_textfile_dir != ""
 
 - name: Node exporter can read anything (omit file permissions)


### PR DESCRIPTION
* Switch `node_exporter_textfile_dir` mode to 775 so group node-exp has permissions to write in the directory.
* Document this change in the README.