### PR TITLE
Add support for multi-line ansible_managed strings

### DIFF
--- a/templates/node_exporter.service.j2
+++ b/templates/node_exporter.service.j2
@@ -1,4 +1,4 @@
-# {{ ansible_managed }}
+{{ ansible_managed | comment }}
 
 [Unit]
 Description=Prometheus Node Exporter


### PR DESCRIPTION
This'll support multi-line ansible_managed strings but will not work on ansible 1.x.