### PR TITLE
simplify automated CPU arch choosing

### DIFF
--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -24,8 +24,8 @@
 - name: Download node_exporter binary to local folder
   become: false
   get_url:
-    url: "https://github.com/prometheus/node_exporter/releases/download/v{{ node_exporter_version }}/node_exporter-{{ node_exporter_version }}.linux-{{ cpu_architecture }}.tar.gz"
-    dest: "/tmp/node_exporter-{{ node_exporter_version }}.linux-{{ cpu_architecture }}.tar.gz"
+    url: "https://github.com/prometheus/node_exporter/releases/download/v{{ node_exporter_version }}/node_exporter-{{ node_exporter_version }}.linux-{{ go_arch }}.tar.gz"
+    dest: "/tmp/node_exporter-{{ node_exporter_version }}.linux-{{ go_arch }}.tar.gz"
     checksum: "sha256:{{ node_exporter_checksum }}"
   register: _download_binary
   until: _download_binary is succeeded
@@ -37,9 +37,9 @@
 - name: Unpack node_exporter binary
   become: false
   unarchive:
-    src: "/tmp/node_exporter-{{ node_exporter_version }}.linux-{{ cpu_architecture }}.tar.gz"
+    src: "/tmp/node_exporter-{{ node_exporter_version }}.linux-{{ go_arch }}.tar.gz"
     dest: "/tmp"
-    creates: "/tmp/node_exporter-{{ node_exporter_version }}.linux-{{ cpu_architecture }}/node_exporter"
+    creates: "/tmp/node_exporter-{{ node_exporter_version }}.linux-{{ go_arch }}/node_exporter"
   delegate_to: localhost
   check_mode: false
 
@@ -51,7 +51,7 @@
 
 - name: Propagate node_exporter binaries
   copy:
-    src: "/tmp/node_exporter-{{ node_exporter_version }}.linux-{{ cpu_architecture }}/node_exporter"
+    src: "/tmp/node_exporter-{{ node_exporter_version }}.linux-{{ go_arch }}/node_exporter"
     dest: "/usr/local/bin/node_exporter"
     mode: 0750
     owner: "{{ node_exporter_system_user }}"

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -24,8 +24,8 @@
 - name: Download node_exporter binary to local folder
   become: false
   get_url:
-    url: "https://github.com/prometheus/node_exporter/releases/download/v{{ node_exporter_version }}/node_exporter-{{ node_exporter_version }}.linux-{{ go_arch_map[ansible_architecture] | default(ansible_architecture) }}.tar.gz"
-    dest: "/tmp/node_exporter-{{ node_exporter_version }}.linux-{{ go_arch_map[ansible_architecture] | default(ansible_architecture) }}.tar.gz"
+    url: "https://github.com/prometheus/node_exporter/releases/download/v{{ node_exporter_version }}/node_exporter-{{ node_exporter_version }}.linux-{{ cpu_architecture }}.tar.gz"
+    dest: "/tmp/node_exporter-{{ node_exporter_version }}.linux-{{ cpu_architecture }}.tar.gz"
     checksum: "sha256:{{ node_exporter_checksum }}"
   register: _download_binary
   until: _download_binary is succeeded
@@ -37,9 +37,9 @@
 - name: Unpack node_exporter binary
   become: false
   unarchive:
-    src: "/tmp/node_exporter-{{ node_exporter_version }}.linux-{{ go_arch_map[ansible_architecture] | default(ansible_architecture) }}.tar.gz"
+    src: "/tmp/node_exporter-{{ node_exporter_version }}.linux-{{ cpu_architecture }}.tar.gz"
     dest: "/tmp"
-    creates: "/tmp/node_exporter-{{ node_exporter_version }}.linux-{{ go_arch_map[ansible_architecture] | default(ansible_architecture) }}/node_exporter"
+    creates: "/tmp/node_exporter-{{ node_exporter_version }}.linux-{{ cpu_architecture }}/node_exporter"
   delegate_to: localhost
   check_mode: false
 
@@ -51,7 +51,7 @@
 
 - name: Propagate node_exporter binaries
   copy:
-    src: "/tmp/node_exporter-{{ node_exporter_version }}.linux-{{ go_arch_map[ansible_architecture] | default(ansible_architecture) }}/node_exporter"
+    src: "/tmp/node_exporter-{{ node_exporter_version }}.linux-{{ cpu_architecture }}/node_exporter"
     dest: "/usr/local/bin/node_exporter"
     mode: 0750
     owner: "{{ node_exporter_system_user }}"

--- a/tasks/preflight.yml
+++ b/tasks/preflight.yml
@@ -20,8 +20,8 @@
     _checksums: "{{ lookup('url', 'https://github.com/prometheus/node_exporter/releases/download/v' + node_exporter_version + '/sha256sums.txt', wantlist=True) | list }}"
   run_once: true
 
-- name: "Get checksum for {{ cpu_architecture }} architecture"
+- name: "Get checksum for {{ go_arch }} architecture"
   set_fact:
     node_exporter_checksum: "{{ item.split(' ')[0] }}"
   with_items: "{{ _checksums }}"
-  when: "('linux-' + cpu_architecture + '.tar.gz') in item"
+  when: "('linux-' + go_arch + '.tar.gz') in item"

--- a/tasks/preflight.yml
+++ b/tasks/preflight.yml
@@ -20,8 +20,8 @@
     _checksums: "{{ lookup('url', 'https://github.com/prometheus/node_exporter/releases/download/v' + node_exporter_version + '/sha256sums.txt', wantlist=True) | list }}"
   run_once: true
 
-- name: "Get checksum for {{ go_arch_map[ansible_architecture] | default(ansible_architecture) }} architecture"
+- name: "Get checksum for {{ cpu_architecture }} architecture"
   set_fact:
     node_exporter_checksum: "{{ item.split(' ')[0] }}"
   with_items: "{{ _checksums }}"
-  when: "('linux-' + (go_arch_map[ansible_architecture] | default(ansible_architecture)) + '.tar.gz') in item"
+  when: "('linux-' + cpu_architecture + '.tar.gz') in item"

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -6,5 +6,7 @@ go_arch_map:
   armv7l: 'armv7'
   armv6l: 'armv6'
 
+cpu_architecture: "{{ go_arch_map[ansible_architecture] | default(ansible_architecture) }}"
+
 node_exporter_system_group: "node-exp"
 node_exporter_system_user: "{{ node_exporter_system_group }}"

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -6,7 +6,7 @@ go_arch_map:
   armv7l: 'armv7'
   armv6l: 'armv6'
 
-cpu_architecture: "{{ go_arch_map[ansible_architecture] | default(ansible_architecture) }}"
+go_arch: "{{ go_arch_map[ansible_architecture] | default(ansible_architecture) }}"
 
 node_exporter_system_group: "node-exp"
 node_exporter_system_user: "{{ node_exporter_system_group }}"


### PR DESCRIPTION
Instead of using `{{ go_arch_map[ansible_architecture] | default(ansible_architecture) }}` everywhere just map it to a variable and use this variable.