### PR TITLE
Better tags and configuration handling

### DIFF
--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -1,4 +1,13 @@
 ---
+- name: Copy the Node Exporter systemd service file
+  template:
+    src: node_exporter.service.j2
+    dest: /etc/systemd/system/node_exporter.service
+    owner: root
+    group: root
+    mode: 0644
+  notify: restart node_exporter
+
 - name: Create texfile collector dir
   file:
     path: "{{ node_exporter_textfile_dir }}"

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -58,12 +58,3 @@
     group: "{{ node_exporter_system_group }}"
   notify: restart node_exporter
   when: not ansible_check_mode
-
-- name: Copy the Node Exporter systemd service file
-  template:
-    src: node_exporter.service.j2
-    dest: /etc/systemd/system/node_exporter.service
-    owner: root
-    group: root
-    mode: 0644
-  notify: restart node_exporter

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -6,22 +6,25 @@
     - "{{ ansible_distribution | lower }}.yml"
     - "{{ ansible_os_family | lower }}.yml"
   tags:
-    - always
+    - node_exporter_install
+    - node_exporter_configure
+    - node_exporter_run
 
 - import_tasks: preflight.yml
   tags:
-    - install
-    - configure
+    - node_exporter_install
+    - node_exporter_configure
+    - node_exporter_run
 
 - import_tasks: install.yml
   become: true
   tags:
-    - install
+    - node_exporter_install
 
 - import_tasks: configure.yml
   become: true
   tags:
-    - configure
+    - node_exporter_configure
 
 - name: Ensure Node Exporter is enabled on boot
   become: true
@@ -30,4 +33,4 @@
     name: node_exporter
     enabled: true
   tags:
-    - run
+    - node_exporter_run


### PR DESCRIPTION
- Port tag naming convention from https://github.com/cloudalchemy/ansible-prometheus/pull/160
- Move systemd file creation to `configure.yml` as this file is also node_exporter configuration.