### PR TITLE
adding remote_src to fix latest ansible modules

### DIFF
--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -56,5 +56,6 @@
     mode: 0750
     owner: "{{ node_exporter_system_user }}"
     group: "{{ node_exporter_system_group }}"
+    remote_src: yes
   notify: restart node_exporter
   when: not ansible_check_mode


### PR DESCRIPTION
Was getting an error: Latest ansible versions require the `remote_src: yes` option now because the module is trying to copy from your host /tmp folder instead of the machine ansible is trying to manage.


```
TASK [node-exporter : Propagate node_exporter binaries] ***************************************************************************************
An exception occurred during task execution. To see the full traceback, use -vvv. The error was: If you are using a module and expect the fileto exist on the remote, see the remote_src option
fatal: [teck-swarm-core-3]: FAILED! => {"changed": false, "msg": "Could not find or access '/tmp/node_exporter-0.17.0.linux-amd64/node_exporter' on the Ansible Controller.\nIf you are using a module and expect the file to exist on the remote, see the remote_src option"}
```

This role edit was tested on a 2018 Macbook Pro 10.14 | Ansible Version: 2.7.5

Machines being configured: Ubuntu 16.04 LTS & 18.04 LTS