### PR TITLE
Update: make delegate_to configurable / add version check to avoid re-install each time

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -16,3 +16,5 @@ node_exporter_enabled_collectors:
 #      ignored-fs-types: "^(sys|proc|auto)fs$"
 
 node_exporter_disabled_collectors: []
+
+node_exporter_delegation: localhost

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -6,6 +6,7 @@ node_exporter_system_group: "node-exp"
 node_exporter_system_user: "{{ node_exporter_system_group }}"
 
 node_exporter_textfile_dir: "/var/lib/node_exporter"
+node_exporter_destination: "/usr/local/bin/node_exporter"
 
 node_exporter_enabled_collectors:
   - systemd

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -33,7 +33,7 @@
   until: _download_binary is succeeded
   retries: 5
   delay: 2
-  delegate_to: "{{ node_exporter_delegation | default(inventory_hostname) }}"
+  delegate_to: "{{ node_exporter_delegation | default(inventory_hostname) }}"
   check_mode: false
 
 - name: Unpack node_exporter binary
@@ -42,19 +42,19 @@
     src: "/tmp/node_exporter-{{ node_exporter_version }}.linux-{{ go_arch }}.tar.gz"
     dest: "/tmp"
     creates: "/tmp/node_exporter-{{ node_exporter_version }}.linux-{{ go_arch }}/node_exporter"
-  delegate_to: "{{ node_exporter_delegation | default(inventory_hostname) }}"
+  delegate_to: "{{ node_exporter_delegation | default(inventory_hostname) }}"
   check_mode: false
 
-- name: Create /usr/local/bin
+- name: "Create {{ node_exporter_destination | dirname }}"
   file:
-    path: /usr/local/bin
+    path: "{{ node_exporter_destination | dirname }}"
     state: directory
     mode: 0755
 
 - name: Propagate node_exporter binaries
   copy:
     src: "/tmp/node_exporter-{{ node_exporter_version }}.linux-{{ go_arch }}/node_exporter"
-    dest: "/usr/local/bin/node_exporter"
+    dest: "{{ node_exporter_destination }}"
     mode: 0750
     owner: "{{ node_exporter_system_user }}"
     group: "{{ node_exporter_system_group }}"

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -33,7 +33,7 @@
   until: _download_binary is succeeded
   retries: 5
   delay: 2
-  delegate_to: localhost
+  delegate_to: "{{ node_exporter_delegation | default(inventory_hostname) }}"
   check_mode: false
 
 - name: Unpack node_exporter binary
@@ -42,7 +42,7 @@
     src: "/tmp/node_exporter-{{ node_exporter_version }}.linux-{{ go_arch }}.tar.gz"
     dest: "/tmp"
     creates: "/tmp/node_exporter-{{ node_exporter_version }}.linux-{{ go_arch }}/node_exporter"
-  delegate_to: localhost
+  delegate_to: "{{ node_exporter_delegation | default(inventory_hostname) }}"
   check_mode: false
 
 - name: Create /usr/local/bin

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -16,8 +16,31 @@
     - node_exporter_configure
     - node_exporter_run
 
+- name: Check if node_exporter is installed
+  stat:
+    path: "{{ node_exporter_destination }}"
+  register: __node_exporter_is_installed
+  tags:
+    - node_exporter_install
+
+- name: See stat (REMOVE THIS LATER)
+  debug:
+    msg: "{{ __node_exporter_is_installed }}"
+
+- name: Gather currently installed node_exporter version (if any)
+  command: "{{ node_exporter_destination }} --version"
+  args:
+    warn: false
+  changed_when: false
+  register: __node_exporter_current_version_output
+  when: __node_exporter_is_installed.stat.exists
+  tags:
+    - node_exporter_install
+    - skip_ansible_lint
+
 - import_tasks: install.yml
   become: true
+  when: (not __node_exporter_is_installed.stat.exists) or (__node_exporter_current_version_output.stderr_lines[0].split(" ")[2] != node_exporter_version)
   tags:
     - node_exporter_install
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -16,28 +16,6 @@
     - node_exporter_configure
     - node_exporter_run
 
-- name: Check if node_exporter is installed
-  stat:
-    path: "{{ node_exporter_destination }}"
-  register: __node_exporter_is_installed
-  tags:
-    - node_exporter_install
-
-- name: See stat (REMOVE THIS LATER)
-  debug:
-    msg: "{{ __node_exporter_is_installed }}"
-
-- name: Gather currently installed node_exporter version (if any)
-  command: "{{ node_exporter_destination }} --version"
-  args:
-    warn: false
-  changed_when: false
-  register: __node_exporter_current_version_output
-  when: __node_exporter_is_installed.stat.exists
-  tags:
-    - node_exporter_install
-    - skip_ansible_lint
-
 - import_tasks: install.yml
   become: true
   when: (not __node_exporter_is_installed.stat.exists) or (__node_exporter_current_version_output.stderr_lines[0].split(" ")[2] != node_exporter_version)

--- a/tasks/preflight.yml
+++ b/tasks/preflight.yml
@@ -27,6 +27,24 @@
       - "item not in node_exporter_enabled_collectors"
   with_items: "{{ node_exporter_disabled_collectors }}"
 
+- name: Check if node_exporter is installed
+  stat:
+    path: "{{ node_exporter_destination }}"
+  register: __node_exporter_is_installed
+  tags:
+    - node_exporter_install
+
+- name: Gather currently installed node_exporter version (if any)
+  command: "{{ node_exporter_destination }} --version"
+  args:
+    warn: false
+  changed_when: false
+  register: __node_exporter_current_version_output
+  when: __node_exporter_is_installed.stat.exists
+  tags:
+    - node_exporter_install
+    - skip_ansible_lint
+
 - block:
     - name: Get latest release
       uri:


### PR DESCRIPTION
# Objectives

 - make `delegate_to` configurable
 - introduce a version check to avoid redoing things each time this role is invoked
 - made `node_exporter` location configurable

# Ticket

Resolves: https://github.com/cloudalchemy/ansible-node-exporter/issues/67