### PR TITLE
reintroduce user management into defaults and add testing user creation

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,8 @@ All variables which can be overridden are stored in [defaults/main.yml](defaults
 | -------------- | ------------- | -----------------------------------|
 | `node_exporter_version` | 0.17.0 | Node exporter package version |
 | `node_exporter_web_listen_address` | "0.0.0.0:9100" | Address on which node exporter will listen |
+| `node_exporter_system_group` | "node-exp" | System group used to run node_exporter |
+| `node_exporter_system_user` | "node-exp" | System user used to run node_exporter |
 | `node_exporter_enabled_collectors` | [ systemd, textfile ] | List of additionally enabled collectors. It adds collectors to [those enabled by default](https://github.com/prometheus/node_exporter#enabled-by-default) |
 | `node_exporter_disabled_collectors` | [] | List of disabled collectors. By default node_exporter disables collectors listed [here](https://github.com/prometheus/node_exporter#disabled-by-default). |
 | `node_exporter_textfile_dir` | "/var/lib/node_exporter" | Directory used by the [Textfile Collector](https://github.com/prometheus/node_exporter#textfile-collector). To get permissions to write metrics in this directory, users must be in `node-exp` system group.

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -2,6 +2,9 @@
 node_exporter_version: 0.17.0
 node_exporter_web_listen_address: "0.0.0.0:9100"
 
+node_exporter_system_group: "node-exp"
+node_exporter_system_user: "{{ node_exporter_system_group }}"
+
 node_exporter_textfile_dir: "/var/lib/node_exporter"
 
 node_exporter_enabled_collectors:

--- a/molecule/alternative/playbook.yml
+++ b/molecule/alternative/playbook.yml
@@ -5,6 +5,8 @@
   roles:
     - ansible-node-exporter
   vars:
+    node_exporter_system_group: "root"
+    node_exporter_system_user: "root"
     node_exporter_textfile_dir: ""
     node_exporter_enabled_collectors:
       - systemd

--- a/molecule/alternative/tests/test_alternative.py
+++ b/molecule/alternative/tests/test_alternative.py
@@ -14,6 +14,11 @@ def test_directories(host):
         assert not d.exists
 
 
+def test_user(host):
+    assert not host.group("node-exp").exists
+    assert not host.user("node-exp").exists
+
+
 def test_service(host):
     s = host.service("node_exporter")
 #    assert s.is_enabled

--- a/molecule/default/tests/test_default.py
+++ b/molecule/default/tests/test_default.py
@@ -26,6 +26,13 @@ def test_files(host):
         assert f.is_file
 
 
+def test_user(host):
+    assert host.group("node-exp").exists
+    assert "node-exp" in host.user("node-exp").groups
+    assert host.user("node-exp").shell == "/usr/sbin/nologin"
+    assert host.user("node-exp").home == "/"
+
+
 def test_service(host):
     s = host.service("node_exporter")
 #    assert s.is_enabled

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -10,6 +10,7 @@
     name: "{{ node_exporter_system_group }}"
     state: present
     system: true
+  when: node_exporter_system_group != "root"
 
 - name: Create the node_exporter user
   user:
@@ -20,6 +21,7 @@
     system: true
     createhome: false
     home: /
+  when: node_exporter_system_user != "root"
 
 - name: Download node_exporter binary to local folder
   become: false

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -7,6 +7,3 @@ go_arch_map:
   armv6l: 'armv6'
 
 go_arch: "{{ go_arch_map[ansible_architecture] | default(ansible_architecture) }}"
-
-node_exporter_system_group: "node-exp"
-node_exporter_system_user: "{{ node_exporter_system_group }}"


### PR DESCRIPTION
Seems like there are use cases where node_exporter might be needed to be run as a different user than one which this role creates.

Only change in a logic is to skip user management (user and group creation) when `node_exporter` is expected to be running as `root`. Otherwise this just moves variables to make setting user visible and documented. Additionally I put some tests around user and group creation.

Spawned by https://github.com/prometheus/node_exporter/issues/1246