### PR TITLE
Refactor preflight checks

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ matrix:
 install:
   - pip install tox-travis git-semver
 script:
-  - tox
+  - ./.travis/test.sh
 deploy:
   provider: script
   skip_cleanup: true

--- a/.travis/test.sh
+++ b/.travis/test.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+if [ "$TRAVIS_PULL_REQUEST" == "false" ]; then
+	tox -- molecule test --all
+else
+	tox -- molecule test -s default --destroy always
+	tox -- molecule test -s alternative --destroy never
+fi

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ All variables which can be overridden are stored in [defaults/main.yml](defaults
 
 | Name           | Default Value | Description                        |
 | -------------- | ------------- | -----------------------------------|
-| `node_exporter_version` | 0.17.0 | Node exporter package version |
+| `node_exporter_version` | 0.17.0 | Node exporter package version. Also accepts latest as parameter. |
 | `node_exporter_web_listen_address` | "0.0.0.0:9100" | Address on which node exporter will listen |
 | `node_exporter_system_group` | "node-exp" | System group used to run node_exporter |
 | `node_exporter_system_user` | "node-exp" | System user used to run node_exporter |

--- a/molecule/latest/molecule.yml
+++ b/molecule/latest/molecule.yml
@@ -1,0 +1,36 @@
+---
+dependency:
+  name: galaxy
+driver:
+  name: docker
+lint:
+  name: yamllint
+platforms:
+  - name: stretch
+    image: paulfantom/debian-molecule:9
+    docker_host: "${DOCKER_HOST:-unix://var/run/docker.sock}"
+    privileged: true
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:ro
+  - name: fedora
+    image: paulfantom/fedora-molecule:27
+    docker_host: "${DOCKER_HOST:-unix://var/run/docker.sock}"
+    privileged: true
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:ro
+provisioner:
+  name: ansible
+  lint:
+    name: ansible-lint
+  playbooks:
+    create: ../default/create.yml
+    prepare: ../default/prepare.yml
+    converge: playbook.yml
+    destroy: ../default/destroy.yml
+scenario:
+  name: latest
+verifier:
+  name: testinfra
+  lint:
+    name: flake8
+    enabled: true

--- a/molecule/latest/playbook.yml
+++ b/molecule/latest/playbook.yml
@@ -1,0 +1,8 @@
+---
+- name: Run role
+  hosts: all
+  any_errors_fatal: true
+  roles:
+    - ansible-node-exporter
+  vars:
+    node_exporter_version: latest

--- a/molecule/latest/tests/test_alternative.py
+++ b/molecule/latest/tests/test_alternative.py
@@ -1,0 +1,27 @@
+import pytest
+import os
+import testinfra.utils.ansible_runner
+
+testinfra_hosts = testinfra.utils.ansible_runner.AnsibleRunner(
+    os.environ['MOLECULE_INVENTORY_FILE']).get_hosts('all')
+
+
+@pytest.mark.parametrize("files", [
+    "/etc/systemd/system/node_exporter.service",
+    "/usr/local/bin/node_exporter"
+])
+def test_files(host, files):
+    f = host.file(files)
+    assert f.exists
+    assert f.is_file
+
+
+def test_service(host):
+    s = host.service("node_exporter")
+    # assert s.is_enabled
+    assert s.is_running
+
+
+def test_socket(host):
+    s = host.socket("tcp://0.0.0.0:9100")
+    assert s.is_listening

--- a/tasks/preflight.yml
+++ b/tasks/preflight.yml
@@ -1,27 +1,54 @@
 ---
+- name: Assert usage of systemd as an init system
+  assert:
+    that: ansible_service_mgr == 'systemd'
+    msg: "This role only works with systemd"
+
+- name: Get systemd version
+  command: systemctl --version
+  changed_when: false
+  check_mode: false
+  register: __systemd_version
+  tags:
+    - skip_ansible_lint
+
+- name: Set systemd version fact
+  set_fact:
+    node_exporter_systemd_version: "{{ __systemd_version.stdout_lines[0].split(' ')[-1] }}"
+
 - name: Naive assertion of proper listen address
   assert:
     that:
       - "':' in node_exporter_web_listen_address"
 
-- name: Fail on unsupported init systems
-  fail:
-    msg: "This module only works with systemd"
-  when: ansible_service_mgr != 'systemd'
-
-- name: Check collectors
-  fail:
-    msg: "Collector cannot be both disabled and enabled"
-  when: item in node_exporter_enabled_collectors
+- name: Assert collectors are not both disabled and enabled at the same time
+  assert:
+    that:
+      - "item in node_exporter_enabled_collectors"
   with_items: "{{ node_exporter_disabled_collectors }}"
 
-- name: Get systemd version
-  shell: systemctl --version | awk '$1 == "systemd" {print $2}'
-  changed_when: false
-  check_mode: false
-  register: node_exporter_systemd_version
-  tags:
-    - skip_ansible_lint
+- block:
+    - name: Get latest release
+      uri:
+        url: "https://api.github.com/repos/prometheus/node_exporter/releases/latest"
+        method: GET
+        return_content: true
+        status_code: 200
+        body_format: json
+        validate_certs: false
+        user: "{{ lookup('env', 'GH_USER') | default(omit) }}"
+        password: "{{ lookup('env', 'GH_TOKEN') | default(omit) }}"
+      no_log: true
+      register: _latest_release
+      until: _latest_release.status == 200
+      retries: 5
+
+    - name: "Set node_exporter version to {{ _latest_release.json.tag_name[1:] }}"
+      set_fact:
+        node_exporter_version: "{{ _latest_release.json.tag_name[1:] }}"
+  when: node_exporter_version == "latest"
+  delegate_to: localhost
+  run_once: true
 
 - name: Get checksum list from github
   set_fact:

--- a/templates/node_exporter.service.j2
+++ b/templates/node_exporter.service.j2
@@ -32,7 +32,7 @@ PrivateTmp=yes
 ProtectHome=yes
 NoNewPrivileges=yes
 
-{% if node_exporter_systemd_version.stdout | int >= 232 %}
+{% if node_exporter_systemd_version | int >= 232 %}
 ProtectSystem=strict
 ProtectControlGroups=true
 ProtectKernelModules=true


### PR DESCRIPTION
- do not use `awk` for getting systemd version
- use `assert` instead of `fail` to provide more meaningful ansible output
- allow to use `latest` as a node_exporter_version. (option ported from ansible-prometheus)
- change order of preflight checks to align with order in ansible-prometheus