### PR TITLE
fix preflight check responsible for collector enablement

### DIFF
--- a/molecule/alternative/playbook.yml
+++ b/molecule/alternative/playbook.yml
@@ -9,4 +9,6 @@
     node_exporter_system_user: "root"
     node_exporter_textfile_dir: ""
     node_exporter_enabled_collectors:
-      - systemd
+      - entropy
+    node_exporter_disabled_collectors:
+      - diskstats

--- a/tasks/preflight.yml
+++ b/tasks/preflight.yml
@@ -24,7 +24,7 @@
 - name: Assert collectors are not both disabled and enabled at the same time
   assert:
     that:
-      - "item in node_exporter_enabled_collectors"
+      - "item not in node_exporter_enabled_collectors"
   with_items: "{{ node_exporter_disabled_collectors }}"
 
 - block:


### PR DESCRIPTION
As in subject. 
Additionally modified alternative test scenario to modify `node_exporter_disabled_collectors`.

fixes #80 