### PR TITLE
Fix systemd service startup ordering

### DIFF
--- a/templates/node_exporter.service.j2
+++ b/templates/node_exporter.service.j2
@@ -2,7 +2,7 @@
 
 [Unit]
 Description=Prometheus Node Exporter
-After=network.target
+After=network-online.target
 
 [Service]
 Type=simple


### PR DESCRIPTION
After=network.target does not provide working IP address to listen.
We have to wait network-online.target instead.

Please refer official doc for the differences.
https://www.freedesktop.org/wiki/Software/systemd/NetworkTarget/