### PR TITLE
Fix wrong size of /home shown by node-exporter

### DIFF
--- a/templates/node_exporter.service.j2
+++ b/templates/node_exporter.service.j2
@@ -29,7 +29,11 @@ SyslogIdentifier=node_exporter
 Restart=always
 
 PrivateTmp=yes
+{% for m in ansible_mounts if m.mount == '/home' %}
+ProtectHome=read-only
+{% else %}
 ProtectHome=yes
+{% endfor %}
 NoNewPrivileges=yes
 
 {% if node_exporter_systemd_version | int >= 232 %}


### PR DESCRIPTION
Node-exporter calculates wrong disk space if /home is a separate partition
since systemd protects /home from it.

Change protection to read-only if /home is a mountpoint.