### PR TITLE
Add retries to package installs

### DIFF
--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -3,6 +3,9 @@
   package:
     name: "{{ item }}"
     state: present
+  register: package_ok
+  retries: 5
+  until: package_ok is success
   with_items: "{{ node_exporter_dependencies }}"
 
 - name: Create the node_exporter group

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -3,9 +3,10 @@
   package:
     name: "{{ item }}"
     state: present
-  register: package_ok
+  register: _install_dep_packages
+  until: _install_dep_packages is success
   retries: 5
-  until: package_ok is success
+  delay: 2
   with_items: "{{ node_exporter_dependencies }}"
 
 - name: Create the node_exporter group


### PR DESCRIPTION
Both YUM and APT consistently display temporary locking when building via packer and ansible

  * retry usually only fires once anecdotally