### PR TITLE
preflight: Fix detection of systemd version for systemd 240+

### DIFF
--- a/tasks/preflight.yml
+++ b/tasks/preflight.yml
@@ -14,7 +14,7 @@
 
 - name: Set systemd version fact
   set_fact:
-    node_exporter_systemd_version: "{{ __systemd_version.stdout_lines[0].split(' ')[-1] }}"
+    node_exporter_systemd_version: "{{ __systemd_version.stdout_lines[0] | regex_replace('^systemd\\s(\\d+).*$', '\\1') }}"
 
 - name: Naive assertion of proper listen address
   assert:


### PR DESCRIPTION
systemd versions starting with 240 use a new string format for `systemctl --version`

See: https://github.com/systemd/systemd/commit/f1028f576664744ecc6f9fbb3707879ebf679659

This PR fixes the detection for systemd 240+ while retaining compatibility for older versions