### PR TITLE
added restartsec and startlimitinterval configurations

### DIFF
--- a/templates/node_exporter.service.j2
+++ b/templates/node_exporter.service.j2
@@ -3,6 +3,7 @@
 [Unit]
 Description=Prometheus Node Exporter
 After=network-online.target
+StartLimitInterval=0
 
 [Service]
 Type=simple
@@ -27,6 +28,7 @@ ExecStart=/usr/local/bin/node_exporter \
 
 SyslogIdentifier=node_exporter
 Restart=always
+RestartSec=1
 
 PrivateTmp=yes
 {% for m in ansible_mounts if m.mount == '/home' %}


### PR DESCRIPTION
By default, when you configure Restart=always as we did, systemd gives up restarting your service if it fails to start more than 5 times within a 10 seconds interval. Forever.
There are two [Unit] configuration options responsible for this:
StartLimitBurst=5
StartLimitInterval=10

The simple fix that always works is to set StartLimitInterval=0. This way, systemd will attempt to restart your service forever.
It’s a good idea to set RestartSec to at least 1 second though, to avoid putting too much stress on your server when things start going wrong.

[Source](https://medium.com/@benmorel/creating-a-linux-service-with-systemd-611b5c8b91d6)