### PR TITLE
make node exporter download URL configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ All variables which can be overridden are stored in [defaults/main.yml](defaults
 | Name           | Default Value | Description                        |
 | -------------- | ------------- | -----------------------------------|
 | `node_exporter_version` | 0.18.1 | Node exporter package version. Also accepts latest as parameter. |
+| `node_exporter_url` | https://github.com/prometheus/node_exporter/releases/download/... | Node exporter package download URL. |
 | `node_exporter_web_listen_address` | "0.0.0.0:9100" | Address on which node exporter will listen |
 | `node_exporter_system_group` | "node-exp" | System group used to run node_exporter |
 | `node_exporter_system_user` | "node-exp" | System user used to run node_exporter |

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,6 +1,7 @@
 ---
 node_exporter_version: 0.18.1
 node_exporter_web_listen_address: "0.0.0.0:9100"
+node_exporter_url: "https://github.com/prometheus/node_exporter/releases/download/v{{ node_exporter_version }}/node_exporter-{{ node_exporter_version }}.linux-{{ go_arch }}.tar.gz"
 
 node_exporter_system_group: "node-exp"
 node_exporter_system_user: "{{ node_exporter_system_group }}"

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -30,7 +30,7 @@
 - name: Download node_exporter binary to local folder
   become: false
   get_url:
-    url: "https://github.com/prometheus/node_exporter/releases/download/v{{ node_exporter_version }}/node_exporter-{{ node_exporter_version }}.linux-{{ go_arch }}.tar.gz"
+    url: "{{ node_exporter_url }}"
     dest: "/tmp/node_exporter-{{ node_exporter_version }}.linux-{{ go_arch }}.tar.gz"
     checksum: "sha256:{{ node_exporter_checksum }}"
   register: _download_binary


### PR DESCRIPTION
For some organisations it might be important to have control over the location where the binary is downloaded from. Thus the URL is made configurable with the old value as default.