### PR TITLE
Run preflight tasks to register variables when check_mode is enabled

### DIFF
--- a/tasks/preflight.yml
+++ b/tasks/preflight.yml
@@ -31,6 +31,7 @@
   stat:
     path: "/usr/local/bin/node_exporter"
   register: __node_exporter_is_installed
+  check_mode: no
   tags:
     - node_exporter_install
 
@@ -40,6 +41,7 @@
     warn: false
   changed_when: false
   register: __node_exporter_current_version_output
+  check_mode: no
   when: __node_exporter_is_installed.stat.exists
   tags:
     - node_exporter_install


### PR DESCRIPTION
When running this playbook with the --check option later tasks fail because the variables from the below two tasks don't run.  Since these two tasks shouldn't change anything on the remote hosts they should be safe to run in check mode.  

I tried to run the tests via `tox` but kept seeing the error `ERROR: InvocationError for command /Users/me/Development/ansible-node-exporter/.tox/py35-ansible28/bin/molecule test -s default (exited with code 1)`.  I'd appreciate some guidance with this error so I could actually run the tests locally, but I don't see why the tests wouldn't pass with this small of a change.  