### PR TITLE
Do not use createhome alias as it seems to break whole system permissions

### DIFF
--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -23,7 +23,7 @@
     append: true
     shell: /usr/sbin/nologin
     system: true
-    createhome: false
+    create_home: false
     home: /
   when: node_exporter_system_user != "root"
 


### PR DESCRIPTION
When module `user` uses `createhome` alias instead of `create_home` it can break system permissions.

Alternative approach to #110 
Closes #110