### PR TITLE
molecule/default/tests: test if permissions of other files are unchanged

### DIFF
--- a/molecule/default/tests/test_default.py
+++ b/molecule/default/tests/test_default.py
@@ -26,6 +26,21 @@ def test_files(host):
         assert f.is_file
 
 
+def test_permissions_didnt_change(host):
+    dirs = [
+        "/etc",
+        "/root",
+        "/usr",
+        "/var"
+    ]
+    for file in dirs:
+        f = host.file(file)
+        assert f.exists
+        assert f.is_directory
+        assert f.user == "root"
+        assert f.group == "root"
+
+
 def test_user(host):
     assert host.group("node-exp").exists
     assert "node-exp" in host.user("node-exp").groups


### PR DESCRIPTION
This is just a sanity check that we don't accidentally change permissions inside `/` directory. It allows us to prevent/check issues like #109 on all supported ansible versions and operating systems.