### PR TITLE
Make node-exporter CentOS 8 compliant

### DIFF
--- a/vars/centos-8.yml
+++ b/vars/centos-8.yml
@@ -1,0 +1,4 @@
+---
+node_exporter_dependencies:
+  - python3-libselinux
+  - python3-policycoreutils


### PR DESCRIPTION
commit 28c7e67aeb62ae53305bfc5f8ee8db38b6ae10de introduced a new
variables file discovery. This caused a CentOS 8 host to match first on
redhat.yaml which is rhel7 specific. Add a vars file for CentOS 8 to
match before.