### PR TITLE
tasks: do not touch any settings of system directory /usr/local/bin

### DIFF
--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -49,12 +49,6 @@
   delegate_to: localhost
   check_mode: false
 
-- name: Create /usr/local/bin
-  file:
-    path: /usr/local/bin
-    state: directory
-    mode: 0755
-
 - name: Propagate node_exporter binaries
   copy:
     src: "/tmp/node_exporter-{{ node_exporter_version }}.linux-{{ go_arch }}/node_exporter"


### PR DESCRIPTION
/usr/local/bin should always exist on target operating system as it
is part of default system layout. If it doesn't exist, it is not
this role reponsibility to create it or change its permissions.