### PR TITLE
tasks: remove already covered entries when choosing an OS specific vars

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -5,6 +5,7 @@
     - "{{ ansible_distribution | lower }}-{{ ansible_distribution_version | lower }}.yml"
     - "{{ ansible_distribution | lower }}-{{ ansible_distribution_major_version | lower }}.yml"
     - "{{ ansible_os_family | lower }}-{{ ansible_distribution_major_version | lower }}.yml"
+    - "{{ ansible_distribution_file_variety | lower }}.yml"
     - "{{ ansible_distribution | lower }}.yml"
     - "{{ ansible_os_family | lower }}.yml"
   tags:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -4,10 +4,8 @@
   with_first_found:
     - "{{ ansible_distribution | lower }}-{{ ansible_distribution_version | lower }}.yml"
     - "{{ ansible_distribution | lower }}-{{ ansible_distribution_major_version | lower }}.yml"
-    - "{{ ansible_distribution_file_variety | lower }}-{{ ansible_distribution_major_version | lower }}.yml"
     - "{{ ansible_os_family | lower }}-{{ ansible_distribution_major_version | lower }}.yml"
     - "{{ ansible_distribution | lower }}.yml"
-    - "{{ ansible_os_family | lower }}-{{ ansible_distribution_version.split('.')[0] }}.yml"
     - "{{ ansible_os_family | lower }}.yml"
   tags:
     - node_exporter_install


### PR DESCRIPTION
`{{ ansible_os_family | lower }}-{{ ansible_distribution_version.split('.')[0] }}.yml` is already covered by `{{ ansible_os_family | lower }}-{{ ansible_distribution_major_version | lower }}.yml`

`{{ ansible_distribution_file_variety | lower }}-{{ ansible_distribution_major_version | lower }}.yml` should be already covered by `{{ ansible_os_family | lower }}-{{ ansible_distribution_major_version | lower }}.yml`

This was checked against CentOS8 and fedora 30, for which these changes were originally targeted.