### PR TITLE
Add CentOS-8 and open Firewall port

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ All variables which can be overridden are stored in [defaults/main.yml](defaults
 | -------------- | ------------- | -----------------------------------|
 | `node_exporter_version` | 0.18.1 | Node exporter package version. Also accepts latest as parameter. |
 | `node_exporter_web_listen_address` | "0.0.0.0:9100" | Address on which node exporter will listen |
+| `node_exporter_open_firewall` | false | Open port for external scraping |
 | `node_exporter_system_group` | "node-exp" | System group used to run node_exporter |
 | `node_exporter_system_user` | "node-exp" | System user used to run node_exporter |
 | `node_exporter_enabled_collectors` | [ systemd, textfile ] | List of additionally enabled collectors. It adds collectors to [those enabled by default](https://github.com/prometheus/node_exporter#enabled-by-default) |

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,6 +1,7 @@
 ---
 node_exporter_version: 0.18.1
 node_exporter_web_listen_address: "0.0.0.0:9100"
+node_exporter_open_firewall: false
 
 node_exporter_system_group: "node-exp"
 node_exporter_system_user: "{{ node_exporter_system_group }}"

--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -27,3 +27,11 @@
   when:
     - ansible_version.full is version_compare('2.4', '>=')
     - ansible_selinux.status == "enabled"
+
+- name: Open Node Exporter port in Firewall
+  firewalld:
+    port: "{{ node_exporter_web_listen_address.split(':')[-1] }}/tcp"
+    immediate: yes
+    permanent: yes
+    state: enabled
+  when: node_exporter_open_firewall|bool

--- a/vars/centos-7.yml
+++ b/vars/centos-7.yml
@@ -1,0 +1,4 @@
+---
+node_exporter_dependencies:
+  - libselinux-python
+  - policycoreutils-python

--- a/vars/centos-8.yml
+++ b/vars/centos-8.yml
@@ -1,0 +1,4 @@
+---
+node_exporter_dependencies:
+  - python3-libselinux
+  - python3-policycoreutils


### PR DESCRIPTION
Role did not allow for firewalld port to be opened for node_exporter service for installs not on same host as Prometheus. Default of false maintains this behavior.
Also added vars files for CentOS-7 and 8.