### PR TITLE
add option to propagate binaries without access to internet

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ All variables which can be overridden are stored in [defaults/main.yml](defaults
 | Name           | Default Value | Description                        |
 | -------------- | ------------- | -----------------------------------|
 | `node_exporter_version` | 0.18.1 | Node exporter package version. Also accepts latest as parameter. |
+| `node_exporter_binaries_local_dir` | "" | Allows to use local packages instead of ones distributed on github. As parameter it takes a directory where `node_exporter` binary is stored on host on which ansible is ran. This overrides `node_exporter_version` parameter |
 | `node_exporter_web_listen_address` | "0.0.0.0:9100" | Address on which node exporter will listen |
 | `node_exporter_system_group` | "node-exp" | System group used to run node_exporter |
 | `node_exporter_system_user` | "node-exp" | System user used to run node_exporter |

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,5 +1,6 @@
 ---
 node_exporter_version: 0.18.1
+node_exporter_binary_local_dir: ''
 node_exporter_web_listen_address: "0.0.0.0:9100"
 
 node_exporter_system_group: "node-exp"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,6 +1,6 @@
 ---
 node_exporter_version: 0.18.1
-node_exporter_binary_local_dir: ''
+node_exporter_binary_local_dir: ""
 node_exporter_web_listen_address: "0.0.0.0:9100"
 
 node_exporter_system_group: "node-exp"

--- a/molecule/alternative/playbook.yml
+++ b/molecule/alternative/playbook.yml
@@ -5,7 +5,7 @@
   roles:
     - ansible-node-exporter
   vars:
-    node_exporter_binary_local_dir: '/tmp/node-exporter-linux-amd64'
+    node_exporter_binary_local_dir: "/tmp/node_exporter-linux-amd64"
     node_exporter_system_group: "root"
     node_exporter_system_user: "root"
     node_exporter_textfile_dir: ""

--- a/molecule/alternative/playbook.yml
+++ b/molecule/alternative/playbook.yml
@@ -5,6 +5,7 @@
   roles:
     - ansible-node-exporter
   vars:
+    node_exporter_binary_local_dir: '/tmp/node-exporter-linux-amd64'
     node_exporter_system_group: "root"
     node_exporter_system_user: "root"
     node_exporter_textfile_dir: ""

--- a/molecule/alternative/prepare.yml
+++ b/molecule/alternative/prepare.yml
@@ -4,7 +4,7 @@
   gather_facts: false
   vars:
     go_arch: amd64
-    node_eqxporter_version: 0.18.1
+    node_exporter_version: 0.18.1
   tasks:
     - name: Download node_exporter binary to local folder
       become: false

--- a/molecule/alternative/prepare.yml
+++ b/molecule/alternative/prepare.yml
@@ -3,14 +3,14 @@
   hosts: localhost
   gather_facts: false
   vars:
-    # Version seeds to be specified here as molecule doesn't have access to ansible_version at this stage
-    version: 0.18.1
+    go_arch: amd64
+    node_eqxporter_version: 0.18.1
   tasks:
     - name: Download node_exporter binary to local folder
       become: false
       get_url:
-        url: "https://github.com/prometheus/node_exporter/releases/download/v{{ version }}/node_exporter-{{ version }}.linux-amd64.tar.gz"
-        dest: "/tmp/node_exporter-{{ version }}.linux-amd64.tar.gz"
+        url: "https://github.com/prometheus/node_exporter/releases/download/v{{ node_exporter_version }}/node_exporter-{{ node_exporter_version }}.linux-{{ go_arch }}.tar.gz"
+        dest: "/tmp/node_exporter-{{ node_exporter_version }}.linux-{{ go_arch }}.tar.gz"
       register: _download_binary
       until: _download_binary is succeeded
       retries: 5
@@ -21,16 +21,16 @@
     - name: Unpack node_exporter binary
       become: false
       unarchive:
-        src: "/tmp/node_exporter-{{ version }}.linux-amd64.tar.gz"
+        src: "/tmp/node_exporter-{{ node_exporter_version }}.linux-{{ go_arch }}.tar.gz"
         dest: "/tmp"
-        creates: "/tmp/node_exporter-{{ version }}.linux-amd64/node_exporter"
+        creates: "/tmp/node_exporter-{{ node_exporter_version }}.linux-{{ go_arch }}/node_exporter"
       run_once: true
       check_mode: false
 
     - name: link to alertmanager binaries directory
       become: false
       file:
-        src: "/tmp/node_exporter-{{ version }}.linux-amd64"
+        src: "/tmp/node_exporter-{{ node_exporter_version }}.linux-amd64"
         dest: "/tmp/node_exporter-linux-amd64"
         state: link
       run_once: true

--- a/molecule/alternative/prepare.yml
+++ b/molecule/alternative/prepare.yml
@@ -9,7 +9,7 @@
     - name: Download node_exporter binary to local folder
       become: false
       get_url:
-        url: "https://github.com/prometheus/node_exporter/releases/download/v{{ node_exporter_version }}/node_exporter-{{ node_exporter_version }}.linux-amd64.tar.gz"
+        url: "https://github.com/prometheus/node_exporter/releases/download/v{{ version }}/node_exporter-{{ version }}.linux-amd64.tar.gz"
         dest: "/tmp/node_exporter-{{ version }}.linux-amd64.tar.gz"
       register: _download_binary
       until: _download_binary is succeeded

--- a/molecule/alternative/prepare.yml
+++ b/molecule/alternative/prepare.yml
@@ -1,5 +1,37 @@
 ---
 - name: Prepare
-  hosts: all
+  hosts: localhost
   gather_facts: false
-  tasks: []
+  vars:
+    # Version seeds to be specified here as molecule doesn't have access to ansible_version at this stage
+    version: 0.18.1
+  tasks:
+    - name: Download node_exporter binary to local folder
+      become: false
+      get_url:
+        url: "https://github.com/prometheus/node_exporter/releases/download/v{{ node_exporter_version }}/node_exporter-{{ node_exporter_version }}.linux-{{ go_arch }}.tar.gz"
+        dest: "/tmp/node_exporter-{{ version }}.linux-{{ go_arch }}.tar.gz"
+      register: _download_binary
+      until: _download_binary is succeeded
+      retries: 5
+      delay: 2
+      run_once: true
+      check_mode: false
+
+    - name: Unpack node_exporter binary
+      become: false
+      unarchive:
+        src: "/tmp/node_exporter-{{ version }}.linux-{{ go_arch }}.tar.gz"
+        dest: "/tmp"
+        creates: "/tmp/node_exporter-{{ version }}.linux-{{ go_arch }}/node_exporter"
+      run_once: true
+      check_mode: false
+
+    - name: link to alertmanager binaries directory
+      become: false
+      file:
+        src: "/tmp/node_exporter-{{ version }}.linux-amd64"
+        dest: "/tmp/node_exporter-linux-amd64"
+        state: link
+      run_once: true
+      check_mode: false

--- a/molecule/alternative/prepare.yml
+++ b/molecule/alternative/prepare.yml
@@ -9,8 +9,8 @@
     - name: Download node_exporter binary to local folder
       become: false
       get_url:
-        url: "https://github.com/prometheus/node_exporter/releases/download/v{{ node_exporter_version }}/node_exporter-{{ node_exporter_version }}.linux-{{ go_arch }}.tar.gz"
-        dest: "/tmp/node_exporter-{{ version }}.linux-{{ go_arch }}.tar.gz"
+        url: "https://github.com/prometheus/node_exporter/releases/download/v{{ node_exporter_version }}/node_exporter-{{ node_exporter_version }}.linux-amd64.tar.gz"
+        dest: "/tmp/node_exporter-{{ version }}.linux-amd64.tar.gz"
       register: _download_binary
       until: _download_binary is succeeded
       retries: 5
@@ -21,9 +21,9 @@
     - name: Unpack node_exporter binary
       become: false
       unarchive:
-        src: "/tmp/node_exporter-{{ version }}.linux-{{ go_arch }}.tar.gz"
+        src: "/tmp/node_exporter-{{ version }}.linux-amd64.tar.gz"
         dest: "/tmp"
-        creates: "/tmp/node_exporter-{{ version }}.linux-{{ go_arch }}/node_exporter"
+        creates: "/tmp/node_exporter-{{ version }}.linux-amd64/node_exporter"
       run_once: true
       check_mode: false
 

--- a/molecule/alternative/prepare.yml
+++ b/molecule/alternative/prepare.yml
@@ -27,7 +27,7 @@
       run_once: true
       check_mode: false
 
-    - name: link to alertmanager binaries directory
+    - name: link to node_exporter binaries directory
       become: false
       file:
         src: "/tmp/node_exporter-{{ node_exporter_version }}.linux-amd64"

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -59,7 +59,7 @@
         group: root
       notify: restart node_exporter
       when: not ansible_check_mode
-  when: node_exporter_binary_local_dir | length = 0
+  when: node_exporter_binary_local_dir | length == 0
 
 - name: propagate locally distributed node_exporter binary
   copy:

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -27,34 +27,46 @@
     home: /
   when: node_exporter_system_user != "root"
 
-- name: Download node_exporter binary to local folder
-  become: false
-  get_url:
-    url: "https://github.com/prometheus/node_exporter/releases/download/v{{ node_exporter_version }}/node_exporter-{{ node_exporter_version }}.linux-{{ go_arch }}.tar.gz"
-    dest: "/tmp/node_exporter-{{ node_exporter_version }}.linux-{{ go_arch }}.tar.gz"
-    checksum: "sha256:{{ node_exporter_checksum }}"
-  register: _download_binary
-  until: _download_binary is succeeded
-  retries: 5
-  delay: 2
-  delegate_to: localhost
-  check_mode: false
+- block:
+    - name: Download node_exporter binary to local folder
+      become: false
+      get_url:
+        url: "https://github.com/prometheus/node_exporter/releases/download/v{{ node_exporter_version }}/node_exporter-{{ node_exporter_version }}.linux-{{ go_arch }}.tar.gz"
+        dest: "/tmp/node_exporter-{{ node_exporter_version }}.linux-{{ go_arch }}.tar.gz"
+        checksum: "sha256:{{ node_exporter_checksum }}"
+      register: _download_binary
+      until: _download_binary is succeeded
+      retries: 5
+      delay: 2
+      delegate_to: localhost
+      check_mode: false
 
-- name: Unpack node_exporter binary
-  become: false
-  unarchive:
-    src: "/tmp/node_exporter-{{ node_exporter_version }}.linux-{{ go_arch }}.tar.gz"
-    dest: "/tmp"
-    creates: "/tmp/node_exporter-{{ node_exporter_version }}.linux-{{ go_arch }}/node_exporter"
-  delegate_to: localhost
-  check_mode: false
+    - name: Unpack node_exporter binary
+      become: false
+      unarchive:
+        src: "/tmp/node_exporter-{{ node_exporter_version }}.linux-{{ go_arch }}.tar.gz"
+        dest: "/tmp"
+        creates: "/tmp/node_exporter-{{ node_exporter_version }}.linux-{{ go_arch }}/node_exporter"
+      delegate_to: localhost
+      check_mode: false
 
-- name: Propagate node_exporter binaries
+    - name: Propagate node_exporter binaries
+      copy:
+        src: "/tmp/node_exporter-{{ node_exporter_version }}.linux-{{ go_arch }}/node_exporter"
+        dest: "/usr/local/bin/node_exporter"
+        mode: 0755
+        owner: root
+        group: root
+      notify: restart node_exporter
+      when: not ansible_check_mode
+  when: node_exporter_binary_local_dir | length = 0
+
+- name: propagate locally distributed node_exporter binary
   copy:
-    src: "/tmp/node_exporter-{{ node_exporter_version }}.linux-{{ go_arch }}/node_exporter"
+    src: "{{ node_exporter_binary_local_dir }}/node_exporter"
     dest: "/usr/local/bin/node_exporter"
     mode: 0755
     owner: root
     group: root
+  when: node_exporter_binary_local_dir | length > 0
   notify: restart node_exporter
-  when: not ansible_check_mode

--- a/tasks/preflight.yml
+++ b/tasks/preflight.yml
@@ -66,7 +66,9 @@
     - name: "Set node_exporter version to {{ _latest_release.json.tag_name[1:] }}"
       set_fact:
         node_exporter_version: "{{ _latest_release.json.tag_name[1:] }}"
-  when: node_exporter_version == "latest"
+  when:
+    - node_exporter_version == "latest"
+    - node_exporter_binary_local_dir | length == 0
   delegate_to: localhost
   run_once: true
 
@@ -74,9 +76,12 @@
   set_fact:
     _checksums: "{{ lookup('url', 'https://github.com/prometheus/node_exporter/releases/download/v' + node_exporter_version + '/sha256sums.txt', wantlist=True) | list }}"
   run_once: true
+  when: node_exporter_binary_local_dir | length == 0
 
 - name: "Get checksum for {{ go_arch }} architecture"
   set_fact:
     node_exporter_checksum: "{{ item.split(' ')[0] }}"
   with_items: "{{ _checksums }}"
-  when: "('linux-' + go_arch + '.tar.gz') in item"
+  when:
+    - "('linux-' + go_arch + '.tar.gz') in item"
+    - node_exporter_binary_local_dir | length == 0

--- a/tasks/preflight.yml
+++ b/tasks/preflight.yml
@@ -72,16 +72,16 @@
   delegate_to: localhost
   run_once: true
 
-- name: Get checksum list from github
-  set_fact:
-    _checksums: "{{ lookup('url', 'https://github.com/prometheus/node_exporter/releases/download/v' + node_exporter_version + '/sha256sums.txt', wantlist=True) | list }}"
-  run_once: true
-  when: node_exporter_binary_local_dir | length == 0
+- block:
+    - name: Get checksum list from github
+      set_fact:
+        _checksums: "{{ lookup('url', 'https://github.com/prometheus/node_exporter/releases/download/v' + node_exporter_version + '/sha256sums.txt', wantlist=True) | list }}"
+      run_once: true
 
-- name: "Get checksum for {{ go_arch }} architecture"
-  set_fact:
-    node_exporter_checksum: "{{ item.split(' ')[0] }}"
-  with_items: "{{ _checksums }}"
-  when:
-    - "('linux-' + go_arch + '.tar.gz') in item"
-    - node_exporter_binary_local_dir | length == 0
+    - name: "Get checksum for {{ go_arch }} architecture"
+      set_fact:
+        node_exporter_checksum: "{{ item.split(' ')[0] }}"
+      with_items: "{{ _checksums }}"
+      when:
+        - "('linux-' + go_arch + '.tar.gz') in item"
+  when: node_exporter_binary_local_dir | length == 0


### PR DESCRIPTION
Same as cloudalchemy/ansible-alertmanager#83 and cloudalchemy/ansible-prometheus#239 but for Node exporter.

This PR should naildown what https://github.com/cloudalchemy/ansible-node-exporter/pull/124 is currently missing.
