### PR TITLE
Use a variable for the installation path

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -2,6 +2,7 @@
 node_exporter_version: 0.18.1
 node_exporter_binary_local_dir: ""
 node_exporter_web_listen_address: "0.0.0.0:9100"
+node_exporter_binary_install: "/usr/local/bin"
 
 node_exporter_system_group: "node-exp"
 node_exporter_system_user: "{{ node_exporter_system_group }}"

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -53,7 +53,7 @@
     - name: Propagate node_exporter binaries
       copy:
         src: "/tmp/node_exporter-{{ node_exporter_version }}.linux-{{ go_arch }}/node_exporter"
-        dest: "/usr/local/bin/node_exporter"
+        dest: "{{ node_exporter_binary_install }}/node_exporter"
         mode: 0755
         owner: root
         group: root
@@ -64,7 +64,7 @@
 - name: propagate locally distributed node_exporter binary
   copy:
     src: "{{ node_exporter_binary_local_dir }}/node_exporter"
-    dest: "/usr/local/bin/node_exporter"
+    dest: "{{ node_exporter_binary_install }}/node_exporter"
     mode: 0755
     owner: root
     group: root

--- a/tasks/preflight.yml
+++ b/tasks/preflight.yml
@@ -29,14 +29,14 @@
 
 - name: Check if node_exporter is installed
   stat:
-    path: "/usr/local/bin/node_exporter"
+    path: "{{ node_exporter_binary_install }}/node_exporter"
   register: __node_exporter_is_installed
   check_mode: false
   tags:
     - node_exporter_install
 
 - name: Gather currently installed node_exporter version (if any)
-  command: "/usr/local/bin/node_exporter --version"
+  command: "{{ node_exporter_binary_install }}/node_exporter --version"
   args:
     warn: false
   changed_when: false

--- a/templates/node_exporter.service.j2
+++ b/templates/node_exporter.service.j2
@@ -9,7 +9,7 @@ StartLimitInterval=0
 Type=simple
 User={{ node_exporter_system_user }}
 Group={{ node_exporter_system_group }}
-ExecStart=/usr/local/bin/node_exporter \
+ExecStart={{ node_exporter_binary_install }}/node_exporter \
 {% for collector in node_exporter_enabled_collectors -%}
 {%   if not collector is mapping %}
     --collector.{{ collector }} \


### PR DESCRIPTION
What does this PR does ?
It add a variable for the installation path and leave a default value

Why :
Some distributions have the /usr/local/bin in read only ( for instance, coreos ) . 
This PR allows a user to specify an installation path if the default is locked. 

J\x00