### PR TITLE
Add OS family archlinux

### DIFF
--- a/vars/archlinux.yml
+++ b/vars/archlinux.yml
@@ -1,0 +1,2 @@
+---
+node_exporter_dependencies: []


### PR DESCRIPTION
I tried to install node-exporter on my Arch Linux server, but it didn't work because a dependencies file for Arch Linux OS family is missing. I tried to copy the empty debian one and it simply worked.