### PR TITLE
move installing selinux package dependencies into separate tasks

### DIFF
--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -1,14 +1,4 @@
 ---
-- name: Install dependencies
-  package:
-    name: "{{ item }}"
-    state: present
-  register: _install_dep_packages
-  until: _install_dep_packages is success
-  retries: 5
-  delay: 2
-  with_items: "{{ node_exporter_dependencies }}"
-
 - name: Create the node_exporter group
   group:
     name: "{{ node_exporter_system_group }}"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,18 +1,4 @@
 ---
-- name: Gather variables for each operating system
-  include_vars: "{{ item }}"
-  with_first_found:
-    - "{{ ansible_distribution | lower }}-{{ ansible_distribution_version | lower }}.yml"
-    - "{{ ansible_distribution | lower }}-{{ ansible_distribution_major_version | lower }}.yml"
-    - "{{ ansible_os_family | lower }}-{{ ansible_distribution_major_version | lower }}.yml"
-    - "{{ ansible_distribution_file_variety | lower }}.yml"
-    - "{{ ansible_distribution | lower }}.yml"
-    - "{{ ansible_os_family | lower }}.yml"
-  tags:
-    - node_exporter_install
-    - node_exporter_configure
-    - node_exporter_run
-
 - import_tasks: preflight.yml
   tags:
     - node_exporter_install
@@ -24,6 +10,12 @@
   when: (not __node_exporter_is_installed.stat.exists) or (__node_exporter_current_version_output.stderr_lines[0].split(" ")[2] != node_exporter_version)
   tags:
     - node_exporter_install
+
+- import_tasks: selinux.yml
+  become: true
+  when: ansible_selinux.status == "enabled"
+  tags:
+    - node_exporter_configure
 
 - import_tasks: configure.yml
   become: true

--- a/tasks/selinux.yml
+++ b/tasks/selinux.yml
@@ -1,0 +1,39 @@
+---
+- name: Install selinux python packages [RHEL]
+  package:
+    name:
+      - "{{ ( (ansible_facts.distribution_major_version | int) < 8) | ternary('libselinux-python','python3-libselinux') }}"
+      - "{{ ( (ansible_facts.distribution_major_version | int) < 8) | ternary('libselinux-python','python3-policycoreutils') }}"
+    state: present
+  register: _install_selinux_packages
+  until: _install_selinux_packages is success
+  retries: 5
+  delay: 2
+  when:
+    - (ansible_distribution | lower == "redhat") or
+      (ansible_distribution | lower == "centos")
+
+- name: Install selinux python packages [Fedora]
+  package:
+    name:
+      - "{{ ( (ansible_facts.distribution_major_version | int) < 29) | ternary('libselinux-python','python3-libselinux') }}"
+      - "{{ ( (ansible_facts.distribution_major_version | int) < 29) | ternary('libselinux-python','python3-policycoreutils') }}"
+    state: present
+  register: _install_selinux_packages
+  until: _install_selinux_packages is success
+  retries: 5
+  delay: 2
+
+  when:
+    - ansible_distribution | lower == "fedora"
+
+- name: Install selinux python packages [clearlinux]
+  package:
+    name: sysadmin-basic
+    state: present
+  register: _install_selinux_packages
+  until: _install_selinux_packages is success
+  retries: 5
+  delay: 2
+  when:
+    - ansible_distribution | lower = "clearlinux"

--- a/vars/clearlinux.yml
+++ b/vars/clearlinux.yml
@@ -1,3 +1,0 @@
----
-node_exporter_dependencies:
-  - sysadmin-basic

--- a/vars/debian.yml
+++ b/vars/debian.yml
@@ -1,2 +1,0 @@
----
-node_exporter_dependencies: []

--- a/vars/fedora.yml
+++ b/vars/fedora.yml
@@ -1,4 +1,0 @@
----
-node_exporter_dependencies:
-  - python3-libselinux
-  - python3-policycoreutils

--- a/vars/redhat-7.yml
+++ b/vars/redhat-7.yml
@@ -1,4 +1,0 @@
----
-node_exporter_dependencies:
-  - libselinux-python
-  - policycoreutils-python

--- a/vars/redhat-8.yml
+++ b/vars/redhat-8.yml
@@ -1,4 +1,0 @@
----
-node_exporter_dependencies:
-  - python3-libselinux
-  - python3-policycoreutils

--- a/vars/suse.yml
+++ b/vars/suse.yml
@@ -1,2 +1,0 @@
----
-node_exporter_dependencies: []


### PR DESCRIPTION
Changing mechanism responsible for installing package dependencies to allow installing role on operating systems that are not yet supported (such as archlinux, PR #130).

The only dependencies are related to selinux, so new mechanism installs them only if selinux is enabled on whitelisted OS distributions. The installation mechanism is abstracted to a separate file for across-role portability reasons.

Mechanism is adapted from [similar solution in kubespray](https://github.com/kubernetes-sigs/kubespray/tree/master/roles/bootstrap-os/tasks).

Closing #130 