### PR TITLE
Add binary install directory

### DIFF
--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -1,4 +1,11 @@
 ---
+- name: create node_exporter binary install directory
+  file:
+    path: "{{ _node_exporter_binary_install_dir }}"
+    state: directory
+    owner: root
+    group: root
+
 - name: Create the node_exporter group
   group:
     name: "{{ node_exporter_system_group }}"
@@ -43,7 +50,7 @@
     - name: Propagate node_exporter binaries
       copy:
         src: "/tmp/node_exporter-{{ node_exporter_version }}.linux-{{ go_arch }}/node_exporter"
-        dest: "/usr/local/bin/node_exporter"
+        dest: "{{ _node_exporter_binary_install_dir }}/node_exporter"
         mode: 0755
         owner: root
         group: root
@@ -54,7 +61,7 @@
 - name: propagate locally distributed node_exporter binary
   copy:
     src: "{{ node_exporter_binary_local_dir }}/node_exporter"
-    dest: "/usr/local/bin/node_exporter"
+    dest: "{{ _node_exporter_binary_install_dir }}/node_exporter"
     mode: 0755
     owner: root
     group: root

--- a/tasks/preflight.yml
+++ b/tasks/preflight.yml
@@ -29,14 +29,14 @@
 
 - name: Check if node_exporter is installed
   stat:
-    path: "/usr/local/bin/node_exporter"
+    path: "{{ _node_exporter_binary_install_dir }}/node_exporter"
   register: __node_exporter_is_installed
   check_mode: false
   tags:
     - node_exporter_install
 
 - name: Gather currently installed node_exporter version (if any)
-  command: "/usr/local/bin/node_exporter --version"
+  command: "{{ _node_exporter_binary_install_dir }}/node_exporter --version"
   args:
     warn: false
   changed_when: false

--- a/templates/node_exporter.service.j2
+++ b/templates/node_exporter.service.j2
@@ -9,7 +9,7 @@ StartLimitInterval=0
 Type=simple
 User={{ node_exporter_system_user }}
 Group={{ node_exporter_system_group }}
-ExecStart=/usr/local/bin/node_exporter \
+ExecStart={{ _node_exporter_binary_install_dir }}/node_exporter \
 {% for collector in node_exporter_enabled_collectors -%}
 {%   if not collector is mapping %}
     --collector.{{ collector }} \

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -7,3 +7,5 @@ go_arch_map:
   armv6l: 'armv6'
 
 go_arch: "{{ go_arch_map[ansible_architecture] | default(ansible_architecture) }}"
+
+_node_exporter_binary_install_dir: "/usr/local/bin"


### PR DESCRIPTION
Binaries are currently droped in /usr/local/bin

This commit add `node_exporter_binary_install_dir` variable where user can
change the binary destination to `/opt/bin` for example.