### PR TITLE
Do not manage system directories

### DIFF
--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -1,11 +1,4 @@
 ---
-- name: create node_exporter binary install directory
-  file:
-    path: "{{ _node_exporter_binary_install_dir }}"
-    state: directory
-    owner: root
-    group: root
-
 - name: Create the node_exporter group
   group:
     name: "{{ node_exporter_system_group }}"


### PR DESCRIPTION
By default node_exporter binary is placed in `/usr/local/bin` which causes removed task to manage this directory. Such "feature" is out of scope of this role and can cause problems in some deployment scenarios.

This is a follow-up to #137