### PR TITLE
Add quotes to node_exporter parametrs in systemd service

### DIFF
--- a/templates/node_exporter.service.j2
+++ b/templates/node_exporter.service.j2
@@ -17,7 +17,7 @@ ExecStart={{ _node_exporter_binary_install_dir }}/node_exporter \
 {%     set name, options = (collector.items()|list)[0] -%}
     --collector.{{ name }} \
 {%     for k,v in options|dictsort %}
-    --collector.{{ name }}.{{ k }}={{ v }} \
+    --collector.{{ name }}.{{ k }}={{ v | quote }} \
 {%     endfor -%}
 {%   endif -%}
 {% endfor -%}


### PR DESCRIPTION
Add quotes to node_exporter parametrs in systemd service.

When using the code like:

```yaml
    - role: cloudalchemy.node-exporter
      node_exporter_enabled_collectors:
        - diskstats:
            ignored-devices: "^(ram|loop|fd)\\d+$"
```

Currently the systemd template for `node_exporter` looks:

```bash
# grep -A2 'ExecStart=' /etc/systemd/system/node_exporter.service
ExecStart=/usr/local/bin/node_exporter \
--collector.diskstats \
    --collector.diskstats.ignored-devices=^(ram|loop|fd)\d+$ \
```

Which is wrong. That's why created this PR which is adding quotes to do it properly:

```
ExecStart=/usr/local/bin/node_exporter \
--collector.diskstats \
    --collector.diskstats.ignored-devices="^(ram|loop|fd)\d+$" \
```
