### PR TITLE
Install 'policycoreutils-python' on redhat/centos < 8 and fedora < 29…

### DIFF
--- a/tasks/selinux.yml
+++ b/tasks/selinux.yml
@@ -3,7 +3,7 @@
   package:
     name:
       - "{{ ( (ansible_facts.distribution_major_version | int) < 8) | ternary('libselinux-python','python3-libselinux') }}"
-      - "{{ ( (ansible_facts.distribution_major_version | int) < 8) | ternary('libselinux-python','python3-policycoreutils') }}"
+      - "{{ ( (ansible_facts.distribution_major_version | int) < 8) | ternary('policycoreutils-python','python3-policycoreutils') }}"
     state: present
   register: _install_selinux_packages
   until: _install_selinux_packages is success
@@ -17,7 +17,7 @@
   package:
     name:
       - "{{ ( (ansible_facts.distribution_major_version | int) < 29) | ternary('libselinux-python','python3-libselinux') }}"
-      - "{{ ( (ansible_facts.distribution_major_version | int) < 29) | ternary('libselinux-python','python3-policycoreutils') }}"
+      - "{{ ( (ansible_facts.distribution_major_version | int) < 29) | ternary('policycoreutils-python','python3-policycoreutils') }}"
     state: present
   register: _install_selinux_packages
   until: _install_selinux_packages is success


### PR DESCRIPTION
… instead of 'libselinux-python' twice

---

We had issues deploying on redhat/centos < 8, which failed with the following error:
```bash
"msg": "Failed to import the required Python library (policycoreutils-python) on <hostname>'s Python /usr/bin/python. Please read module documentation and install in the appropriate location. If the required library is installed, but Ansible is using the wrong Python interpreter, please consult the documentation on ansible_python_interpreter"
```

Both `libselinux` and `policycoreutils` needs to be installed on centos with selinux. The change in the PR fixed our issues.