### PR TITLE
More token usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,12 @@ Before running node_exporter role, user needs to provision their own certificate
       randomuser: examplepassword 
 ```
 
+### GitHub rate-limiting
+
+When this role fails with 400 errors during requests while downloading node-exporter (and checksums) from GitHub, you can use the following environment variables to authenticate yourself with GitHub:
+
+ - `GH_USER`: user name of your GitHub account
+ - `GH_TOKEN`: a personal access token (scope: `public_repo`)
 
 ### Demo site
 

--- a/tasks/preflight.yml
+++ b/tasks/preflight.yml
@@ -107,4 +107,7 @@
       with_items: "{{ _checksums }}"
       when:
         - "('linux-' + go_arch + '.tar.gz') in item"
-  when: node_exporter_binary_local_dir | length == 0
+  when:
+    - node_exporter_binary_local_dir | length == 0
+    - not __node_exporter_is_installed.stat.exists or
+      (__node_exporter_current_version_output.stderr_lines[0].split(" ")[2] != node_exporter_version)

--- a/tasks/preflight.yml
+++ b/tasks/preflight.yml
@@ -96,9 +96,26 @@
   run_once: true
 
 - block:
+    - name: Setup variable with GH_TOKEN
+      set_fact:
+        _gh_token: "{{ lookup('env', 'GH_TOKEN') | default('') }}"
+      delegate_to: localhost
+      run_once: true
+
+    - name: Setup Authorization headers with GH_TOKEN
+      set_fact:
+        _lookup_headers:
+          Authorization: "Bearer {{ hostvars['localhost']['_gh_token'] }}"
+      when: (hostvars['localhost']['_gh_token'] is defined)
+
+    - name: Setup empty headers
+      set_fact:
+        _lookup_headers: {}
+      when: _lookup_headers is not defined
+
     - name: Get checksum list from github
       set_fact:
-        _checksums: "{{ lookup('url', 'https://github.com/prometheus/node_exporter/releases/download/v' + node_exporter_version + '/sha256sums.txt', wantlist=True) | list }}"
+        _checksums: "{{ lookup('url', 'https://github.com/prometheus/node_exporter/releases/download/v' + node_exporter_version + '/sha256sums.txt', headers=_lookup_headers, wantlist=True) | list }}"
       run_once: true
 
     - name: "Get checksum for {{ go_arch }} architecture"


### PR DESCRIPTION
I did a couple things (as a first pass):

 - document `GH_USER`/`GH_TOKEN` in `README.md`
 - add a `when` codition, so checksums are only gathered when necessary (this gets me halfway there)
 - allow usage of the `GH_TOKEN` when checksums are gathered

So far, this seems to work.

I have tested the following:

- [x] running install (no expected change)
- [x] running install with node-exporter update (expected change)
- [x] a fresh install
- [ ] a fresh install with `GH_TOKEN`

Resolves: cloudalchemy/ansible-node-exporter#165