### PR TITLE
Use localhost to fetch checksums

### DIFF
--- a/tasks/preflight.yml
+++ b/tasks/preflight.yml
@@ -107,4 +107,5 @@
       with_items: "{{ _checksums }}"
       when:
         - "('linux-' + go_arch + '.tar.gz') in item"
+  delegate_to: localhost
   when: node_exporter_binary_local_dir | length == 0


### PR DESCRIPTION
Avoid fetching checksums on every node by delegating the checksum fetch
to localhost.

Fixes: https://github.com/cloudalchemy/ansible-node-exporter/issues/165

[fix]

Signed-off-by: Ben Kochie <superq@gmail.com>