### PR TITLE
Move StartLimitInterval to [Service] section

### DIFF
--- a/templates/node_exporter.service.j2
+++ b/templates/node_exporter.service.j2
@@ -3,7 +3,6 @@
 [Unit]
 Description=Prometheus Node Exporter
 After=network-online.target
-StartLimitInterval=0
 
 [Service]
 Type=simple
@@ -32,6 +31,7 @@ ExecStart={{ _node_exporter_binary_install_dir }}/node_exporter \
 SyslogIdentifier=node_exporter
 Restart=always
 RestartSec=1
+StartLimitInterval=0
 
 PrivateTmp=yes
 {% for m in ansible_mounts if m.mount == '/home' %}


### PR DESCRIPTION
### Problem

For CentOS 7.8, there is a warning message in `/var/log/message`: 
```
systemd: [/etc/systemd/system/node_exporter.service:8] Unknown lvalue 'StartLimitInterval' in section 'Unit'
```

### Potential solution

I'm on CentOS 7.8, and when check with doc of `systemd.service` with `man systemd.service`.

I can see `StartLimitInterval=, StartLimitBurst=` is here. So maybe it's a good idea to move this option to [Service] section.

