### PR TITLE
set file mode explicitly when downloading binary

### DIFF
--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -24,6 +24,7 @@
         url: "https://github.com/prometheus/node_exporter/releases/download/v{{ node_exporter_version }}/node_exporter-{{ node_exporter_version }}.linux-{{ go_arch }}.tar.gz"
         dest: "/tmp/node_exporter-{{ node_exporter_version }}.linux-{{ go_arch }}.tar.gz"
         checksum: "sha256:{{ node_exporter_checksum }}"
+        mode: '0666'
       register: _download_binary
       until: _download_binary is succeeded
       retries: 5

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -24,7 +24,7 @@
         url: "https://github.com/prometheus/node_exporter/releases/download/v{{ node_exporter_version }}/node_exporter-{{ node_exporter_version }}.linux-{{ go_arch }}.tar.gz"
         dest: "/tmp/node_exporter-{{ node_exporter_version }}.linux-{{ go_arch }}.tar.gz"
         checksum: "sha256:{{ node_exporter_checksum }}"
-        mode: '0666'
+        mode: '0644'
       register: _download_binary
       until: _download_binary is succeeded
       retries: 5


### PR DESCRIPTION
Set file mode explicitly when downloading binary because the default mode has changed after this [security fix](https://github.com/ansible/ansible/issues/67794) was introduced in ansible.

Fixes: https://github.com/cloudalchemy/ansible-node-exporter/issues/177.