### PR TITLE
optionally allow node_exporter access to shared /tmp

### DIFF
--- a/templates/node_exporter.service.j2
+++ b/templates/node_exporter.service.j2
@@ -33,7 +33,6 @@ Restart=always
 RestartSec=1
 StartLimitInterval=0
 
-PrivateTmp=yes
 {% for m in ansible_mounts if m.mount == '/home' %}
 ProtectHome=read-only
 {% else %}


### PR DESCRIPTION
by default node_exporter.service sets PrivateTmp=yes which prevents
node_exporter from monitoring the actual /tmp, e.g. for children mount
points.