### PR TITLE
Skip systemd service management in check mode

### DIFF
--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -5,3 +5,5 @@
     daemon_reload: true
     name: node_exporter
     state: restarted
+  when:
+    - not ansible_check_mode

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -32,5 +32,7 @@
     name: node_exporter
     enabled: true
     state: started
+  when:
+    - not ansible_check_mode
   tags:
     - node_exporter_run


### PR DESCRIPTION
Default behaviour has been changed in ansible 2.10, running this role in check
mode was failing with the following error:

fatal: [XXXXX]: FAILED! => {"changed": false, "msg": "Could not find the requested service node_exporter: host"}

See https://github.com/ansible/ansible/issues/72721 and
https://github.com/ansible/ansible/pull/68136 for more information.