### PR TITLE
Support for downloading artifacts without direct access to GitHub

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ All variables which can be overridden are stored in [defaults/main.yml](defaults
 | Name           | Default Value | Description                        |
 | -------------- | ------------- | -----------------------------------|
 | `node_exporter_version` | 1.0.1 | Node exporter package version. Also accepts latest as parameter. |
+| `node_exporter_download_url` | "https://github.com/prometheus/node_exporter/releases/download" | Base URL for downloading `node_exporter` binaries and checksums. Useful for installation without direct access to GitHub. The `node_exporter_version` parameter is still supported, but using latest requires direct access to GitHub API. |
 | `node_exporter_binary_local_dir` | "" | Allows to use local packages instead of ones distributed on github. As parameter it takes a directory where `node_exporter` binary is stored on host on which ansible is ran. This overrides `node_exporter_version` parameter |
 | `node_exporter_web_listen_address` | "0.0.0.0:9100" | Address on which node exporter will listen |
 | `node_exporter_enabled_collectors` | [ systemd, textfile ] | List of additionally enabled collectors. It adds collectors to [those enabled by default](https://github.com/prometheus/node_exporter#enabled-by-default) |

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,5 +1,6 @@
 ---
 node_exporter_version: 1.0.1
+node_exporter_download_url: "https://github.com/prometheus/node_exporter/releases/download"
 node_exporter_binary_local_dir: ""
 node_exporter_web_listen_address: "0.0.0.0:9100"
 

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -21,7 +21,7 @@
     - name: Download node_exporter binary to local folder
       become: false
       get_url:
-        url: "https://github.com/prometheus/node_exporter/releases/download/v{{ node_exporter_version }}/node_exporter-{{ node_exporter_version }}.linux-{{ go_arch }}.tar.gz"
+        url: "{{ node_exporter_download_url }}/v{{ node_exporter_version }}/node_exporter-{{ node_exporter_version }}.linux-{{ go_arch }}.tar.gz"
         dest: "/tmp/node_exporter-{{ node_exporter_version }}.linux-{{ go_arch }}.tar.gz"
         checksum: "sha256:{{ node_exporter_checksum }}"
         mode: '0644'

--- a/tasks/preflight.yml
+++ b/tasks/preflight.yml
@@ -98,7 +98,7 @@
 - block:
     - name: Get checksum list from github
       set_fact:
-        _checksums: "{{ lookup('url', 'https://github.com/prometheus/node_exporter/releases/download/v' + node_exporter_version + '/sha256sums.txt', wantlist=True) | list }}"
+        _checksums: "{{ lookup('url', node_exporter_download_url + '/v' + node_exporter_version + '/sha256sums.txt', wantlist=True) | list }}"
       run_once: true
 
     - name: "Get checksum for {{ go_arch }} architecture"


### PR DESCRIPTION
This PR adds a new role parameter to facilitate downloading of the node-exporter binaries and checksums without direct access to GitHub. I tried to use the existing role parameter `node_exporter_binary_local_dir`, but then I loose a lot of functionality provided by the role like:

- Default node-exporter version
- Checksum verification of the downloaded binary archive
- Orchestration of the download on Ansible controller
