### PR TITLE
.circleci: run 'latest' scenario only if available

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,7 +36,7 @@ jobs:
            echo 'No alternative test'
          fi
       - run: |
-         if [[ -z "${CIRCLE_PULL_REQUEST}" ]]; then
+         if [[ -z "${CIRCLE_PULL_REQUEST}" ]] && [[ -d 'molecule/latest' ]]; then
            molecule test -s latest --destroy never
          else
            echo 'Not running latest on PR'


### PR DESCRIPTION
`latest` scenario can be unavailable in some repositories. This should allow skipping scenario if it isn't available.