### PR TITLE
Set telemetry_path in yaml

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ All variables which can be overridden are stored in [defaults/main.yml](defaults
 | `node_exporter_version` | 1.0.1 | Node exporter package version. Also accepts latest as parameter. |
 | `node_exporter_binary_local_dir` | "" | Allows to use local packages instead of ones distributed on github. As parameter it takes a directory where `node_exporter` binary is stored on host on which ansible is ran. This overrides `node_exporter_version` parameter |
 | `node_exporter_web_listen_address` | "0.0.0.0:9100" | Address on which node exporter will listen |
+| `node_exporter_web_telemetry_path` | "/metrics" | Path under which to expose metrics |
 | `node_exporter_enabled_collectors` | ```["systemd",{textfile: {directory: "{{node_exporter_textfile_dir}}"}}]``` | List of dicts defining additionally enabled collectors and their configuration. It adds collectors to [those enabled by default](https://github.com/prometheus/node_exporter#enabled-by-default). |
 | `node_exporter_disabled_collectors` | [] | List of disabled collectors. By default node_exporter disables collectors listed [here](https://github.com/prometheus/node_exporter#disabled-by-default). |
 | `node_exporter_textfile_dir` | "/var/lib/node_exporter" | Directory used by the [Textfile Collector](https://github.com/prometheus/node_exporter#textfile-collector). To get permissions to write metrics in this directory, users must be in `node-exp` system group. __Note__: More information in TROUBLESHOOTING.md guide.

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -4,6 +4,7 @@ node_exporter_binary_local_dir: ""
 node_exporter_web_listen_address: "0.0.0.0:9100"
 
 node_exporter_textfile_dir: "/var/lib/node_exporter"
+node_exporter_telemetry_path: "/metrics"
 
 node_exporter_tls_server_config: {}
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -2,9 +2,9 @@
 node_exporter_version: 1.0.1
 node_exporter_binary_local_dir: ""
 node_exporter_web_listen_address: "0.0.0.0:9100"
+node_exporter_web_telemetry_path: "/metrics"
 
 node_exporter_textfile_dir: "/var/lib/node_exporter"
-node_exporter_telemetry_path: "/metrics"
 
 node_exporter_tls_server_config: {}
 

--- a/templates/node_exporter.service.j2
+++ b/templates/node_exporter.service.j2
@@ -26,6 +26,7 @@ ExecStart={{ _node_exporter_binary_install_dir }}/node_exporter \
 {% if node_exporter_tls_server_config | length > 0 or node_exporter_http_server_config | length > 0 or node_exporter_basic_auth_users | length > 0 %}
     --web.config=/etc/node_exporter/config.yaml \
 {% endif %}
+    --web.telemetry-path={{ node_exporter_telemetry_path }}
     --web.listen-address={{ node_exporter_web_listen_address }}
 
 SyslogIdentifier=node_exporter

--- a/templates/node_exporter.service.j2
+++ b/templates/node_exporter.service.j2
@@ -26,8 +26,8 @@ ExecStart={{ _node_exporter_binary_install_dir }}/node_exporter \
 {% if node_exporter_tls_server_config | length > 0 or node_exporter_http_server_config | length > 0 or node_exporter_basic_auth_users | length > 0 %}
     --web.config=/etc/node_exporter/config.yaml \
 {% endif %}
-    --web.telemetry-path={{ node_exporter_telemetry_path }}
-    --web.listen-address={{ node_exporter_web_listen_address }}
+    --web.listen-address={{ node_exporter_web_listen_address }} \
+    --web.telemetry-path={{ node_exporter_web_telemetry_path }}
 
 SyslogIdentifier=node_exporter
 Restart=always


### PR DESCRIPTION
Allows to set `node_exporter_telemetry_path: /my/endpoint` as variable to get  `--web.telemetry-path=/my/endpoint` as command line parameter for the node_exporter.