### PR TITLE
.circleci: fix getting last commit message during release

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -55,8 +55,7 @@ jobs:
       - run: git config --global user.name "${GIT_USER}"
       - run: |
           GIT_TAG=none
-          echo "Last commit message: ${GIT_COMMIT_DESC}"
-          case "${GIT_COMMIT_DESC}" in
+          case "$(git log --format=oneline -n 1 $CIRCLE_SHA1)" in
             *"[patch]"*|*"[fix]"*|*"[bugfix]"* )   GIT_TAG=$(git semver --next-patch) ;;
             *"[minor]"*|*"[feat]"*|*"[feature]"* ) GIT_TAG=$(git semver --next-minor) ;;
             *"[major]"*|*"[breaking change]"* )    GIT_TAG=$(git semver --next-major) ;;


### PR DESCRIPTION
`GIT_COMMIT_DESC` is undefined in circleci and needs to be replaced with `git log` command.

As a test, we can merge this with `[patch]` as a new patch release is needed either way.