### PR TITLE
Set systemd ProtectHome to read-only for all mountpaths below /home

### DIFF
--- a/templates/node_exporter.service.j2
+++ b/templates/node_exporter.service.j2
@@ -34,7 +34,7 @@ Restart=always
 RestartSec=1
 StartLimitInterval=0
 
-{% for m in ansible_mounts if m.mount == '/home' %}
+{% for m in ansible_mounts if m.mount.startswith('/home') %}
 ProtectHome=read-only
 {% else %}
 ProtectHome=yes


### PR DESCRIPTION
Otherwise statfs for a fs mounted on /home/xxxx will have permission
issues, even if node-exp is granted access to the path through group
membership or setfacl.