### PR TITLE
Fix parse warning in systemd service file. When a lot of regexp chars…

### DIFF
--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -1,4 +1,13 @@
 ---
+- name: Copy the node_exporter wrapper
+  template:
+    src: wrapper.sh.j2
+    dest: "{{ _node_exporter_binary_install_dir }}/node_exporter.wrapper.sh"
+    owner: root
+    group: root
+    mode: 0755
+  notify: restart node_exporter
+
 - name: Copy the node_exporter systemd service file
   template:
     src: node_exporter.service.j2

--- a/templates/node_exporter.service.j2
+++ b/templates/node_exporter.service.j2
@@ -8,26 +8,7 @@ After=network-online.target
 Type=simple
 User={{ _node_exporter_system_user }}
 Group={{ _node_exporter_system_group }}
-ExecStart={{ _node_exporter_binary_install_dir }}/node_exporter \
-{% for collector in node_exporter_enabled_collectors -%}
-{%   if not collector is mapping %}
-    --collector.{{ collector }} \
-{%   else -%}
-{%     set name, options = (collector.items()|list)[0] -%}
-    --collector.{{ name }} \
-{%     for k,v in options|dictsort %}
-    --collector.{{ name }}.{{ k }}={{ v | quote }} \
-{%     endfor -%}
-{%   endif -%}
-{% endfor -%}
-{% for collector in node_exporter_disabled_collectors %}
-    --no-collector.{{ collector }} \
-{% endfor %}
-{% if node_exporter_tls_server_config | length > 0 or node_exporter_http_server_config | length > 0 or node_exporter_basic_auth_users | length > 0 %}
-    --web.config=/etc/node_exporter/config.yaml \
-{% endif %}
-    --web.listen-address={{ node_exporter_web_listen_address }} \
-    --web.telemetry-path={{ node_exporter_web_telemetry_path }}
+ExecStart=/bin/bash {{ _node_exporter_binary_install_dir }}/node_exporter.wrapper.sh
 
 SyslogIdentifier=node_exporter
 Restart=always

--- a/templates/wrapper.sh.j2
+++ b/templates/wrapper.sh.j2
@@ -1,0 +1,20 @@
+exec {{ _node_exporter_binary_install_dir }}/node_exporter \
+{% for collector in node_exporter_enabled_collectors -%}
+{%   if not collector is mapping %}
+    --collector.{{ collector }} \
+{%   else -%}
+{%     set name, options = (collector.items()|list)[0] -%}
+    --collector.{{ name }} \
+{%     for k,v in options|dictsort %}
+    --collector.{{ name }}.{{ k }}={{ v | quote }} \
+{%     endfor -%}
+{%   endif -%}
+{% endfor -%}
+{% for collector in node_exporter_disabled_collectors %}
+    --no-collector.{{ collector }} \
+{% endfor %}
+{% if node_exporter_tls_server_config | length > 0 or node_exporter_http_server_config | length > 0 or node_exporter_basic_auth_users | length > 0 %}
+    --web.config=/etc/node_exporter/config.yaml \
+{% endif %}
+    --web.listen-address={{ node_exporter_web_listen_address }} \
+    --web.telemetry-path={{ node_exporter_web_telemetry_path }}


### PR DESCRIPTION
When put
`--collector.filesystem.ignored-fs-types=^(sys|proc|auto|fuse.lxc)fs$ --collector.filesystem.ignored-mount-points=^/(sys|proc|dev|run|var/lib/docker/.+|etc/network/interfaces.dynamic.d)($|/) --collector.diskstats --collector.diskstats.ignored-devices=^(ram|loop|fd|(h|s|v|xv)d[a-z]|nvme\d+n\d+p)\d+$ `
into node-exporter.service, the systemd is writing errors in the log of node-exporter. It still works though, but I don't like errors in logs.