### PR TITLE
Support arch armv8l

### DIFF
--- a/vars/main.yml
+++ b/vars/main.yml
@@ -5,5 +5,6 @@ go_arch_map:
   aarch64: 'arm64'
   armv7l: 'armv7'
   armv6l: 'armv6'
+  armv8l: 'armv7'
 
 go_arch: "{{ go_arch_map[ansible_architecture] | default(ansible_architecture) }}"


### PR DESCRIPTION
This architecture ID was found on an LXC container running a 32-bit
Debian userland under a 64-bit Raspberry OS kernel. The change allowed
the proper installation of node exporter in this setup.