### PR TITLE
Add options to specify node-exporter user uid and gid

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -26,3 +26,7 @@ node_exporter_disabled_collectors: []
 _node_exporter_binary_install_dir: "/usr/local/bin"
 _node_exporter_system_group: "node-exp"
 _node_exporter_system_user: "{{ _node_exporter_system_group }}"
+
+# node-exp user uid and gid, leave undefined for system default
+#_node_exporter_system_user_uid:
+#_node_exporter_system_group_gid:

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -4,6 +4,7 @@
     name: "{{ _node_exporter_system_group }}"
     state: present
     system: true
+    gid: "{{ _node_exporter_system_group_gid | default(omit) }}"
   when: _node_exporter_system_group != "root"
 
 - name: Create the node_exporter user
@@ -15,6 +16,7 @@
     system: true
     create_home: false
     home: /
+    uid: "{{ _node_exporter_system_user_uid | default(omit) }}"
   when: _node_exporter_system_user != "root"
 
 - block:


### PR DESCRIPTION

Hello,

it would be very useful if we had an option to explicitly specify the uid/gid of the node-exp user.
Our use case for this option is node-exporter access to nfs mounts (node_filesystem_* checks et al.).
Since default node-exp uids/gids can vary from nfs client to client (depending on already created local users/groups) we would need to be able to "anchor" them to a specific ones in order to allow access on the nfs server.

This PR doesn't change the behavior of the role, only allows the new variables to be uncommented and set if a user needs this functionality.
If there is anything else i should do re. this PR feel free to let me know.

br,
Petar
