### PR TITLE
configurable download directory on ansible host

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ All variables which can be overridden are stored in [defaults/main.yml](defaults
 | -------------- | ------------- | -----------------------------------|
 | `node_exporter_version` | 1.1.2 | Node exporter package version. Also accepts latest as parameter. |
 | `node_exporter_binary_local_dir` | "" | Allows to use local packages instead of ones distributed on github. As parameter it takes a directory where `node_exporter` binary is stored on host on which ansible is ran. This overrides `node_exporter_version` parameter |
+| `node_exporter_download_dir` | "/tmp" | Allows to configure an alternative download directory. As parameter it takes a directory where `node_exporter` binary will be downloaded on host on which ansible is ran. Useful for caching in CI jobs |
 | `node_exporter_web_listen_address` | "0.0.0.0:9100" | Address on which node exporter will listen |
 | `node_exporter_web_telemetry_path` | "/metrics" | Path under which to expose metrics |
 | `node_exporter_enabled_collectors` | ```["systemd",{textfile: {directory: "{{node_exporter_textfile_dir}}"}}]``` | List of dicts defining additionally enabled collectors and their configuration. It adds collectors to [those enabled by default](https://github.com/prometheus/node_exporter#enabled-by-default). |
@@ -75,7 +76,7 @@ Before running node_exporter role, the user needs to provision their own certifi
       cert_file: /etc/node_exporter/tls.cert
       key_file: /etc/node_exporter/tls.key
     node_exporter_basic_auth_users:
-      randomuser: examplepassword 
+      randomuser: examplepassword
 ```
 
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -22,6 +22,8 @@ node_exporter_enabled_collectors:
 
 node_exporter_disabled_collectors: []
 
+node_exporter_download_dir: /tmp
+
 # Internal variables.
 _node_exporter_binary_install_dir: "/usr/local/bin"
 _node_exporter_system_group: "node-exp"

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -22,7 +22,7 @@
       become: false
       get_url:
         url: "https://github.com/prometheus/node_exporter/releases/download/v{{ node_exporter_version }}/node_exporter-{{ node_exporter_version }}.linux-{{ go_arch }}.tar.gz"
-        dest: "/tmp/node_exporter-{{ node_exporter_version }}.linux-{{ go_arch }}.tar.gz"
+        dest: "{{ node_exporter_download_dir }}/node_exporter-{{ node_exporter_version }}.linux-{{ go_arch }}.tar.gz"
         checksum: "sha256:{{ node_exporter_checksum }}"
         mode: '0644'
       register: _download_binary
@@ -35,21 +35,20 @@
     - name: Unpack node_exporter binary
       become: false
       unarchive:
-        src: "/tmp/node_exporter-{{ node_exporter_version }}.linux-{{ go_arch }}.tar.gz"
-        dest: "/tmp"
-        creates: "/tmp/node_exporter-{{ node_exporter_version }}.linux-{{ go_arch }}/node_exporter"
+        src: "{{ node_exporter_download_dir }}/node_exporter-{{ node_exporter_version }}.linux-{{ go_arch }}.tar.gz"
+        dest: "{{ node_exporter_download_dir }}"
+        creates: "{{ node_exporter_download_dir }}/node_exporter-{{ node_exporter_version }}.linux-{{ go_arch }}/node_exporter"
       delegate_to: localhost
       check_mode: false
 
     - name: Propagate node_exporter binaries
       copy:
-        src: "/tmp/node_exporter-{{ node_exporter_version }}.linux-{{ go_arch }}/node_exporter"
+        src: "{{ node_exporter_download_dir }}/node_exporter-{{ node_exporter_version }}.linux-{{ go_arch }}/node_exporter"
         dest: "{{ _node_exporter_binary_install_dir }}/node_exporter"
         mode: 0755
         owner: root
         group: root
       notify: restart node_exporter
-      when: not ansible_check_mode
   when: node_exporter_binary_local_dir | length == 0
 
 - name: propagate locally distributed node_exporter binary


### PR DESCRIPTION
Allows to configure an alternative download directory. As parameter it takes a directory where `node_exporter` binary will be downloaded on host on which ansible is ran. Useful for caching in CI jobs

also: copy task doesn't need to be excluded as local download is also run in check_mode.