### PR TITLE
remove recurse from textfile collector dir

### DIFF
--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -36,8 +36,7 @@
     state: directory
     owner: "{{ _node_exporter_system_user }}"
     group: "{{ _node_exporter_system_group }}"
-    recurse: true
-    mode: u+rwX,g+rwX,o=rX
+    mode: '0775'
   when: node_exporter_textfile_dir | length > 0
 
 - name: Allow node_exporter port in SELinux on RedHat OS family


### PR DESCRIPTION
disable recursively changing permissions on files in textfile collector dir. IMO this is out of scope for the ansible role. 

scripts that write to that directory should ensure that node_exporter can read the file. It's ok if the output files belong to root or another user.

if recurse is not set, the mode can be simplyfied. symoblic permissions were introduced in #150 