### PR TITLE
Fix bug in conditional in tasks/main.yml

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -9,7 +9,7 @@
   become: true
   when:
     ( not __node_exporter_is_installed.stat.exists ) or
-    ( __node_exporter_current_version_output.stderr_lines[0].split(" ")[2] != node_exporter_version ) or
+    ( __node_exporter_current_version_output.stdout_lines[0].split(" ")[2] != node_exporter_version ) or
     ( node_exporter_binary_local_dir | length > 0 )
   tags:
     - node_exporter_install


### PR DESCRIPTION
Closes #230 

## Summary
The object `__node_exporter_current_version_output.stderr_lines` is an empty list which causes the following bug in the `tasks/main.yml/install.yml` conditional. This bug happens only **after** provisioning the role for the first time.

```yaml
TASK [cloudalchemy.node_exporter : Create the node_exporter group] ***********************************************************
fatal: [infra-mon-1]: FAILED! => 
  msg: |-
    The conditional check '( not __node_exporter_is_installed.stat.exists ) or ( __node_exporter_current_version_output.stderr_lines[0].split(" ")[2] != node_exporter_version ) or ( node_exporter_binary_local_dir | length > 0 )' failed. The error was: error while evaluating conditional (( not __node_exporter_is_installed.stat.exists ) or ( __node_exporter_current_version_output.stderr_lines[0].split(" ")[2] != node_exporter_version ) or ( node_exporter_binary_local_dir | length > 0 )): list object has no element 0
  
    The error appears to be in '/home/dan/.ansible/roles/cloudalchemy.node_exporter/tasks/install.yml': line 2, column 3, but may
    be elsewhere in the file depending on the exact syntax problem.
  
    The offending line appears to be:
  
    ---
    - name: Create the node_exporter group
      ^ here
```

Content of the `__node_exporter_current_version_output` object
```
TASK [cloudalchemy.node_exporter : debug] ************************************************************************************
ok: [infra-mon-1] => 
  __node_exporter_current_version_output:
    changed: false
    cmd:
    - /usr/local/bin/node_exporter
    - --version
    delta: '0:00:00.003559'
    end: '2021-07-28 19:17:56.937383'
    failed: false
    rc: 0
    start: '2021-07-28 19:17:56.933824'
    stderr: ''
    stderr_lines: []
    stdout: |-
      node_exporter, version 1.2.0 (branch: HEAD, revision: 12968948aec1e2b216a2ecefc45cf3a50671aecb)
        build user:       root@6b17174de526
        build date:       20210715-16:35:54
        go version:       go1.16.6
        platform:         linux/amd64
    stdout_lines:
    - 'node_exporter, version 1.2.0 (branch: HEAD, revision: 12968948aec1e2b216a2ecefc45cf3a50671aecb)'
    - '  build user:       root@6b17174de526'
    - '  build date:       20210715-16:35:54'
    - '  go version:       go1.16.6'
    - '  platform:         linux/amd64'

```

The correct attribute to use to perform the conditional is `stdout_lines`.

## Ansible Versions Tested
This bug is present on both Ansible `2.9.24` and Ansible `4.3.0`

With this small fix I confirm that Ansible executes the playbook successfully without errors. 