### PR TITLE
fix #230

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -9,7 +9,8 @@
   become: true
   when:
     ( not __node_exporter_is_installed.stat.exists ) or
-    ( __node_exporter_current_version_output.stderr_lines[0].split(" ")[2] != node_exporter_version ) or
+    ( (__node_exporter_current_version_output.stderr_lines | length > 0) and (__node_exporter_current_version_output.stderr_lines[0].split(" ")[2] != node_exporter_version) ) or
+    ( (__node_exporter_current_version_output.stdout_lines | length > 0) and (__node_exporter_current_version_output.stdout_lines[0].split(" ")[2] != node_exporter_version) ) or
     ( node_exporter_binary_local_dir | length > 0 )
   tags:
     - node_exporter_install


### PR DESCRIPTION
Fix PR: 231
Closes #230
Summary
The object __node_exporter_current_version_output.stderr_lines is an empty list which causes the following bug in the tasks/main.yml/install.yml conditional. This bug happens only after provisioning the role for the first time.

```
TASK [cloudalchemy.node_exporter : Create the node_exporter group] ***********************************************************
fatal: [infra-mon-1]: FAILED! => 
  msg: |-
    The conditional check '( not __node_exporter_is_installed.stat.exists ) or ( __node_exporter_current_version_output.stderr_lines[0].split(" ")[2] != node_exporter_version ) or ( node_exporter_binary_local_dir | length > 0 )' failed. The error was: error while evaluating conditional (( not __node_exporter_is_installed.stat.exists ) or ( __node_exporter_current_version_output.stderr_lines[0].split(" ")[2] != node_exporter_version ) or ( node_exporter_binary_local_dir | length > 0 )): list object has no element 0
  
    The error appears to be in '/home/dan/.ansible/roles/cloudalchemy.node_exporter/tasks/install.yml': line 2, column 3, but may
    be elsewhere in the file depending on the exact syntax problem.
  
    The offending line appears to be:
  
    ---
    - name: Create the node_exporter group
      ^ here
```

Added backward compatiblity  checking stdout and stderr
