### PR TITLE
Add Rocky Linux support

### DIFF
--- a/tasks/selinux.yml
+++ b/tasks/selinux.yml
@@ -11,7 +11,8 @@
   delay: 2
   when:
     - (ansible_distribution | lower == "redhat") or
-      (ansible_distribution | lower == "centos")
+      (ansible_distribution | lower == "centos") or
+      (ansible_distribution | lower == "rocky")
 
 - name: Install selinux python packages [Fedora]
   package:


### PR DESCRIPTION
This is a workaround because Rocky Linux is not identified as RedHat until Ansible 2.11.
https://forums.rockylinux.org/t/ansible-os-family-question/3320