### PR TITLE
Add support for more command line flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,10 @@ All variables which can be overridden are stored in [defaults/main.yml](defaults
 | -------------- | ------------- | -----------------------------------|
 | `node_exporter_version` | 1.1.2 | Node exporter package version. Also accepts latest as parameter. |
 | `node_exporter_binary_local_dir` | "" | Allows to use local packages instead of ones distributed on github. As parameter it takes a directory where `node_exporter` binary is stored on host on which ansible is ran. This overrides `node_exporter_version` parameter |
+| `node_exporter_web_max_requests` | 40 | Maximum number of parallel scrape requests. Use 0 to disable.  |
+| `node_exporter_web_disable_exporter_metrics` | false | Exclude metrics about the exporter itself (promhttp_*, process_*, go_*). |
+| `node_exporter_log_level` | info | Only log messages with the given severity or above. One of: [debug, info, warn, error]. |
+| `node_exporter_log_format` | logfmt | Output format of log messages. One of: [logfmt, json] |
 | `node_exporter_web_listen_address` | "0.0.0.0:9100" | Address on which node exporter will listen |
 | `node_exporter_web_telemetry_path` | "/metrics" | Path under which to expose metrics |
 | `node_exporter_enabled_collectors` | ```["systemd",{textfile: {directory: "{{node_exporter_textfile_dir}}"}}]``` | List of dicts defining additionally enabled collectors and their configuration. It adds collectors to [those enabled by default](https://github.com/prometheus/node_exporter#enabled-by-default). |

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -3,6 +3,10 @@ node_exporter_version: 1.1.2
 node_exporter_binary_local_dir: ""
 node_exporter_web_listen_address: "0.0.0.0:9100"
 node_exporter_web_telemetry_path: "/metrics"
+node_exporter_web_max_requests: 40
+node_exporter_web_disable_exporter_metrics: false
+node_exporter_log_level: info
+node_exporter_log_format: logfmt
 
 node_exporter_textfile_dir: "/var/lib/node_exporter"
 

--- a/templates/node_exporter.service.j2
+++ b/templates/node_exporter.service.j2
@@ -27,7 +27,13 @@ ExecStart={{ _node_exporter_binary_install_dir }}/node_exporter \
     --web.config=/etc/node_exporter/config.yaml \
 {% endif %}
     --web.listen-address={{ node_exporter_web_listen_address }} \
-    --web.telemetry-path={{ node_exporter_web_telemetry_path }}
+    --web.telemetry-path={{ node_exporter_web_telemetry_path }} \
+{% if node_exporter_web_disable_exporter_metrics %}
+    --web.disable-exporter-metrics \
+{% endif %}
+    --web.max-requests={{ node_exporter_web_max_requests }} \
+    --log.level={{ node_exporter_log_level }} \
+    --log.format={{ node_exporter_log_format }}
 
 SyslogIdentifier=node_exporter
 Restart=always


### PR DESCRIPTION
This commit introduce support for 4 more command line flags namely:
* `--web.max-requests` --> `node_exporter_web_max_requests`
* `--web.disable-exporter-metrics` --> `node_exporter_web_disable_exporter_metrics`
* `--log.level` --> `node_exporter_log_level`
* `--log.format` --> `node_exporter_log_format`

Fixes: #154 