### PR TITLE
Check that TLS cert and key can be read

### DIFF
--- a/tasks/preflight.yml
+++ b/tasks/preflight.yml
@@ -38,17 +38,30 @@
       stat:
         path: "{{ node_exporter_tls_server_config.cert_file }}"
       register: __node_exporter_cert_file
+      become: true
+      become_user: "{{ _node_exporter_system_user }}"
 
     - name: Check existence of TLS key file
       stat:
         path: "{{ node_exporter_tls_server_config.key_file }}"
       register: __node_exporter_key_file
+      become: true
+      become_user: "{{ _node_exporter_system_user }}"
 
     - name: Assert that TLS key and cert are present
       assert:
         that:
           - "{{ __node_exporter_cert_file.stat.exists }}"
           - "{{ __node_exporter_key_file.stat.exists }}"
+
+    - name: Assert that node_exporter can read TLS key and cert
+      assert:
+        that:
+          - "{{ __node_exporter_cert_file.stat.readable }}"
+          - "{{ __node_exporter_key_file.stat.readable }}"
+        msg: >-
+          {{ _node_exporter_system_user }} system user does not have read
+          permission on the TLS key and/or certificate.
   when: node_exporter_tls_server_config | length > 0
 
 - name: Check if node_exporter is installed


### PR DESCRIPTION
### Summary

This pull request adds an extra assertion to the preflight checks to confirm that the node_exporter process has read permission on the TLS key and certificate.

### Background

When we tried setting up the node exporter with TLS we found that the playbook ran successfully but that the node exporter was not running on the target server.
The error messages from `systemctl status node_exporter` did not contain useful information.
Eventually we traced the problem to the TLS certificate having `r-------- root root` permissions and therefore not being accessible to the `node-exp` system account.
Adding this extra check will prevent this happening to others.

### To test

I have not updated the `molecule` tests as there were no equivalent tests on the other preflight assertions.  To trigger the assertion manually, you can run `chmod 0000 /path/to/your/tls.key` and then apply the role.  It should fail during the preflight tests.

Thank you for your work on this role!

