### PR TITLE
Ambient Capabilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ All variables which can be overridden are stored in [defaults/main.yml](defaults
 | `node_exporter_tls_server_config` | {} | Configuration for TLS authentication. Keys and values are the same as in [node_exporter docs](https://github.com/prometheus/node_exporter/blob/master/https/README.md#sample-config). |
 | `node_exporter_http_server_config` | {} | Config for HTTP/2 support. Keys and values are the same as in [node_exporter docs](https://github.com/prometheus/node_exporter/blob/master/https/README.md#sample-config). |
 | `node_exporter_basic_auth_users` | {} | Dictionary of users and password for basic authentication. Passwords are automatically hashed with bcrypt. |
+| `node_exporter_ambient_capabilities` | [] | [Capabilities](https://man7.org/linux/man-pages/man7/capabilities.7.html) added to the `node_exporter` executable. |
 
 ## Example
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -22,6 +22,10 @@ node_exporter_enabled_collectors:
 
 node_exporter_disabled_collectors: []
 
+# A list of Ambient Capabilities to enable for the `node_exporter` process.
+# See the systemd.exec manpage for more information.
+node_exporter_ambient_capabilities: []
+
 # Internal variables.
 _node_exporter_binary_install_dir: "/usr/local/bin"
 _node_exporter_system_group: "node-exp"

--- a/templates/node_exporter.service.j2
+++ b/templates/node_exporter.service.j2
@@ -41,6 +41,10 @@ ProtectHome=yes
 {% endfor %}
 NoNewPrivileges=yes
 
+{% if node_exporter_ambient_capabilities | length > 0 %}
+AmbientCapabilities={{ node_exporter_ambient_capabilities | join(" ") }}
+{% endif %}
+
 {% if node_exporter_systemd_version | int >= 232 %}
 ProtectSystem=strict
 ProtectControlGroups=true


### PR DESCRIPTION
Make it possible to add capabilities to the node_exporter process.

One particularly useful capability¹ to set is `CAP_DAC_READ_SEARCH`
which makes `node_exporter` able to read the whole filesystem even
though it might not otherwise have permission to do so.


1: Being able to read `/var/lib/docker/volumes/` without running as `root` was the driver
   behind this PR.