### PR TITLE
Support setting CPUShares

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ All variables which can be overridden are stored in [defaults/main.yml](defaults
 | `node_exporter_tls_server_config` | {} | Configuration for TLS authentication. Keys and values are the same as in [node_exporter docs](https://github.com/prometheus/node_exporter/blob/master/https/README.md#sample-config). |
 | `node_exporter_http_server_config` | {} | Config for HTTP/2 support. Keys and values are the same as in [node_exporter docs](https://github.com/prometheus/node_exporter/blob/master/https/README.md#sample-config). |
 | `node_exporter_basic_auth_users` | {} | Dictionary of users and password for basic authentication. Passwords are automatically hashed with bcrypt. |
+| `node_exporter_cpu_shares` | 0 | [CPUShares](https://www.freedesktop.org/software/systemd/man/systemd.exec.html) to add to the `node_exporter` executable. Can be useful if node_exporter gets starved for resources. |
 
 ## Example
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -22,6 +22,8 @@ node_exporter_enabled_collectors:
 
 node_exporter_disabled_collectors: []
 
+node_exporter_cpu_shares: 0
+
 # Internal variables.
 _node_exporter_binary_install_dir: "/usr/local/bin"
 _node_exporter_system_group: "node-exp"

--- a/templates/node_exporter.service.j2
+++ b/templates/node_exporter.service.j2
@@ -41,6 +41,10 @@ ProtectHome=yes
 {% endfor %}
 NoNewPrivileges=yes
 
+{% if node_exporter_cpu_shares | int > 0 %}
+CPUShares={{ node_exporter_cpu_shares }}
+{% endif %}
+
 {% if node_exporter_systemd_version | int >= 232 %}
 ProtectSystem=strict
 ProtectControlGroups=true


### PR DESCRIPTION
Useful if `node_exporter` gets starved for resources so that it can't respond in time.