### PR TITLE
Remove deprecated warn flag in newer Ansible command module

### DIFF
--- a/tasks/preflight.yml
+++ b/tasks/preflight.yml
@@ -61,8 +61,6 @@
 
 - name: Gather currently installed node_exporter version (if any)
   command: "{{ _node_exporter_binary_install_dir }}/node_exporter --version"
-  args:
-    warn: false
   changed_when: false
   register: __node_exporter_current_version_output
   check_mode: false


### PR DESCRIPTION
Running this role on recent Ansible versions fails due to the usage of a deprecated/removed warn flag in the command module.