### PR TITLE
Fix checking node exporter version by removing deprecated arguments

### DIFF
--- a/tasks/preflight.yml
+++ b/tasks/preflight.yml
@@ -61,8 +61,7 @@
 
 - name: Gather currently installed node_exporter version (if any)
   command: "{{ _node_exporter_binary_install_dir }}/node_exporter --version"
-  args:
-    warn: false
+  ignore_errors: true
   changed_when: false
   register: __node_exporter_current_version_output
   check_mode: false


### PR DESCRIPTION
Closes #276 